### PR TITLE
Upload screen changes to show the progress bars 

### DIFF
--- a/src/style/uploader.less
+++ b/src/style/uploader.less
@@ -133,6 +133,7 @@
 
 #uploader--demo-button {
   appearance: none;
+  margin-bottom: 30px;
   background-color: @demo;
   color: @demo-text;
   border: 1px solid @demo;
@@ -455,6 +456,22 @@
   margin: 10px 0px 20px;
   font-size: 15px;
 }
+
+
+// to control collapsing on the load screen
+#uploader--demo, 
+#uploader--file-input--label, 
+#uploader--url-message, 
+.uploader--or {
+  transition: all 0.15s;
+  &.collapsing {
+    overflow: hidden;
+    padding: 0;
+  }
+
+}
+
+
 
 #uploader--proxy-popup {
   display: none;

--- a/src/views/uploader.html
+++ b/src/views/uploader.html
@@ -22,24 +22,26 @@
       <div class="uploader--tagline">Rapidly generate a summary tree and begin exploring your data.</div>
 
       <div class="uploader--entry-points">
-        <button id="uploader--demo-button"><span class="symbol">&#9654;</span>Run <span class="selection">SARS-CoV-2</span> demo</button>
-        <form id="uploader--demo-form">
-          <p  class="uploader--demo-option">
-            <label>
-              <input type="radio" name="filename" value="ma_sars_cov_2.maple" checked/>
-              <span>SARS-CoV-2</span>
-            </label>
-            <a href="ma_sars_cov_2.maple" target="_" >
-              <span class="box"><span class="glyph"></span></span>Download input data
-            </a>
-          </p>
-        </form>
+        <div id="uploader--demo">
+          <button id="uploader--demo-button"><span class="symbol">&#9654;</span>Run <span class="selection">SARS-CoV-2</span> demo</button>
+          <form id="uploader--demo-form">
+            <p  class="uploader--demo-option">
+              <label>
+                <input type="radio" name="filename" value="ma_sars_cov_2.maple" checked/>
+                <span>SARS-CoV-2</span>
+              </label>
+              <a href="ma_sars_cov_2.maple" target="_" >
+                <span class="box"><span class="glyph"></span></span>Download input data
+              </a>
+            </p>
+          </form>
+        </div>
       
         <div class="uploader--or">or</div>
 
 
         <input type="file" id="uploader--file-input" name="uploader--file-input">
-        <label for="uploader--file-input" class="uploader--message">
+        <label id="uploader--file-input--label" for="uploader--file-input" class="uploader--message">
           Click here or drag a file to open
           <br/><span class="file-types">.maple, .fasta, or .dphy</span>
           <p class="uploader--byline">All files stay on your system. Nothing is uploaded to the server.</p>

--- a/src/views/uploader.html
+++ b/src/views/uploader.html
@@ -57,7 +57,7 @@
           </p>
           <form id="uploader--url-form">
             <input type="text" id="uploader--url-input" 
-              placeholder="Enter the URL of a .maple, .fasta, or .dphy file"/>
+              placeholder="Enter URL"/>
           </form>
         </div>
         


### PR DESCRIPTION
Our load screen has gotten very tall, and a side effect is that the loading bars are likely to end up below the fold: 

https://github.com/user-attachments/assets/8750713c-8e2e-4e18-a5e1-3e1c198012a5

This change collapses the unused inputs in order to bring the progress bars above the fold

https://github.com/user-attachments/assets/fec6a3a8-5dae-4ffe-adda-1b9142765652

