### PR TITLE
fix sentences in errors

### DIFF
--- a/src/ts/errors.ts
+++ b/src/ts/errors.ts
@@ -44,32 +44,32 @@ const onError = (err: ErrorEvent)=>{
     switch(stage) {
     case STAGES.initialization:
       msg = "Could not initialize delphy. Please check your network connection and try again.";
-      msg += "If you continue to have trouble, please let us know at delphy@fathom.info.";
+      msg += " If you continue to have trouble, please let us know at delphy@fathom.info.";
       break;
     case STAGES.selecting:
-      msg = "Something went wrong while trying to select your file. ";
+      msg = "Something went wrong while trying to select your file.";
       break;
     case STAGES.loading:
       msg = "Could not load file. Please check your network connection and try again.";
-      msg += "If you continue to have trouble, please let us know at delphy@fathom.info.";
+      msg += " If you continue to have trouble, please let us know at delphy@fathom.info.";
       break;
     case STAGES.parsing:
       if  (isBadSafari()) {
         msg = SAFARI_26_2_ERR_MSG;
       } else {
-        msg = "Could not parse your file. Please check that the fasta file is formatted correctly, reload the page, and try again. ";
-        msg += "If you continue to have trouble, please let us know at delphy@fathom.info.";
+        msg = "Could not parse your file. Please check that the fasta file is formatted correctly, reload the page, and try again.";
+        msg += " If you continue to have trouble, please let us know at delphy@fathom.info.";
       }
       showFormatCallback();
       break;
     case STAGES.loaded:
       msg = "An unknown error occured while running your file. Please try again.";
-      msg += "If you continue to have trouble, please let us know at delphy@fathom.info.";
+      msg += " If you continue to have trouble, please let us know at delphy@fathom.info.";
       showFormatCallback();
       break;
     case STAGES.resetting:
       msg = "An unknown error encountered while resetting the parameters. If you reload the page and edit the parameters before the run, it should work fine.";
-      msg += "If you continue to have trouble, please let us know at delphy@fathom.info.";
+      msg += " If you continue to have trouble, please let us know at delphy@fathom.info.";
       showFormatCallback();
       break;
     }


### PR DESCRIPTION
Noticed a text formatting issue (spaces between sentences) in an error recently. (I think the SharedArrayBuffer error only happened this one time; I haven't seen it otherwise.)

<img width="1262" height="968" alt="Screenshot 2026-03-24 at 6 04 53 pm" src="https://github.com/user-attachments/assets/bc10515f-9e56-42ff-be33-1577cf95b47d" />
