### PR TITLE
Add hovers to the gamma chart

### DIFF
--- a/src/style/common.less
+++ b/src/style/common.less
@@ -153,11 +153,12 @@
   --trace-chart-graph-width: 180px;
   --trace-chart-width: var(--trace-chart-graph-width);
   --trace-chart-height: 225px;
+  --pop-chart-highlight-dot-radius: 3px;
   --pop-chart-graph-width: calc(
       var(--indicator-trace-module-width)
     + var(--view-gap)
     + var(--trace-chart-width)
-    + 6px
+    + 2 * var(--pop-chart-highlight-dot-radius)
   );
   --chart-graph-burn-in-trend-stroke-dasharray: var(--chart-graph-trend-stroke-weight) calc(var(--chart-graph-trend-stroke-weight) * 2);
   --chart-position-axis-stroke-weight: var(--position-line-stroke-weight);

--- a/src/style/common.less
+++ b/src/style/common.less
@@ -154,10 +154,10 @@
   --trace-chart-width: var(--trace-chart-graph-width);
   --trace-chart-height: 225px;
   --pop-chart-graph-width: calc(
-    var(--view-gap) / 2
-    + var(--indicator-trace-module-width)
-    + var(--chart-yaxis-width)
-    + var(--trace-chart-graph-width)
+      var(--indicator-trace-module-width)
+    + var(--view-gap)
+    + var(--trace-chart-width)
+    + 6px
   );
   --chart-graph-burn-in-trend-stroke-dasharray: var(--chart-graph-trend-stroke-weight) calc(var(--chart-graph-trend-stroke-weight) * 2);
   --chart-position-axis-stroke-weight: var(--position-line-stroke-weight);
@@ -210,13 +210,9 @@
     var(--chart-yaxis-height) +
     var(--chart-xaxis-height)
   );
-  --indicator-pop-module-width: calc(
-    var(--chart-yaxis-width) +
-    var(--chart-stroke-weight) +
-    var(--pop-chart-graph-width) +
-    var(--chart-stroke-weight)
-  );
+  --indicator-pop-module-width: calc(var(--indicator-trace-module-width) * 2 + var(--view-gap));
   --indicator-module-header-title-max-width: calc(var(--indicator-module-width) - var(--module-header-readout-basis-width) - var(--view-header-gap));
+  --pop-chart-yaxis-width: calc( var(--indicator-trace-module-width) - var(--trace-chart-width));
   --tree-max-height: calc(
     (
       (var(--indicator-module-height) * 3) +

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -485,6 +485,11 @@ nav button:not(:disabled):hover {
   background-color: rgb(from var(--info-fill) r g b / var(--info-fill-opacity-static));
   transition: background-color var(--transition) ease-in-out;
 
+  &:hover {
+    background-color: rgb(from var(--info-fill) r g b / var(--info-fill-opacity-on));
+  }
+
+
   .icon {
     position: absolute;
     top: 5%;

--- a/src/style/runner.less
+++ b/src/style/runner.less
@@ -854,7 +854,9 @@
         // .labels {
         //   opacity: 0;
         // }
-
+        .scrim {
+          fill-opacity: 0.6;
+        }
         .highlight {
           opacity: 1;
         }
@@ -909,8 +911,10 @@
 
         .scrim {
           fill: white;
-          fill-opacity: 0.6;
+          fill-opacity: 0;
+          transition: fill-opacity 0.15s;
         }
+
         .highlight {
           opacity: 0;
           ellipse {

--- a/src/style/runner.less
+++ b/src/style/runner.less
@@ -847,10 +847,17 @@
       max-width: var(--indicator-pop-module-width);
 
 
+      &.highlighting .chart .highlight {
+        opacity: 1;
+      }
+
+
       .displays {
         padding: var(--chart-displays-timeline-inset-x) 0;
         height: var(--trace-chart-width);
       }
+
+
 
       .chart {
         width: fit-content;
@@ -884,6 +891,7 @@
         //   stroke: var(--chart-graph-run-trend-stroke);
         // }
         .highlight {
+          opacity: 0;
           ellipse {
             fill: var(--chart-graph-run-trend-stroke);
             stroke: none;
@@ -893,11 +901,16 @@
           }
         }
 
+        line.highlight {
+          stroke: var(--chart-graph-run-trend-stroke);
+          stroke-opacity: 0.3;
+        }
+
 
         .axis.y {
-          width: 37px;
-          // height: var(--chart-yaxis-height);
+          width: var(--pop-chart-yaxis-width);
           height: var(--trace-chart-width);
+          // background-color: pink;
           line {
             stroke-width: 0.5;
             stroke: var(--chart-graph-run-trend-stroke);
@@ -905,17 +918,35 @@
             &.mag {opacity: 1;}
           }
           text {
+            font-size: 11px;
             alignment-baseline: middle;
             text-anchor: end;
+            &.highlight {
+              fill: #094e77;
+              text-anchor: start;
+            }
           }
         }
 
         .axis.x {
-          margin-left: 37px; // var(--chart-yaxis-width);
-          margin-right: unset;
+          position: relative;
+          margin-left: 3px;
+          margin-right: 3px;
           margin-top: 3px;
-          width: var(--pop-chart-graph-width);
+          width: calc(var(--pop-chart-graph-width) - 6px);
           .min-date {flex-grow: 1;}
+          .min-date, .max-date {
+            &.hidden {
+              display: inherit !important;
+              opacity: 0;
+            }
+          }
+          .hover-date {
+            position: absolute;
+            width: 86px;
+            margin-left: -43px;
+            white-space: nowrap;
+          }
         }
       }
     }

--- a/src/style/runner.less
+++ b/src/style/runner.less
@@ -920,10 +920,9 @@
           text {
             font-size: 11px;
             alignment-baseline: middle;
-            text-anchor: end;
+            text-anchor: start;
             &.highlight {
               fill: #094e77;
-              text-anchor: start;
             }
           }
         }

--- a/src/style/runner.less
+++ b/src/style/runner.less
@@ -47,22 +47,17 @@
         // height: 100%;
         white-space: nowrap;
         overflow: visible;
-        &h3 {
-          font-weight: var(--title-font-weight);
-          font-size: var(--title-font-size);
-          line-height: var(--title-line-height);
-          display: inline-block;
-          width: auto;
-          max-width: 100%;
-          // color: var(--title-text);
-          overflow: visible;
-          white-space: nowrap;
-          text-overflow: ellipsis;
-        }
+
         sub {
           display: inline-block;
           margin-top: 3px;
         }
+      }
+      .subtitle {
+        font-weight: 400;
+        color:  #5e5e5e;
+        font-size: var(--chart-xaxis-hover-text-font-size);
+        margin: 0.5em 0;
       }
 
     }
@@ -283,7 +278,16 @@
 #runner--bottom {
   display: flex;
   flex-direction: row;
-  gap: inherit;
+  /*
+  hack for gamma chart to visually align with
+  trend charts. See explanation at in this file
+  at
+    .population .chart .graph.display {margin-left}
+  and related is
+    #runner--panel--modules {padding}
+  */
+
+  gap: calc(var(--view-gap) - var(--pop-chart-highlight-dot-radius));
   height: calc(100% - 64px);
 }
 
@@ -308,7 +312,6 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-
 
 
   .display {
@@ -848,9 +851,9 @@
 
 
       &.highlighting .chart {
-        .labels {
-          opacity: 0;
-        }
+        // .labels {
+        //   opacity: 0;
+        // }
 
         .highlight {
           opacity: 1;
@@ -874,6 +877,18 @@
           min-width: var(--pop-chart-graph-width);
           max-width: var(--pop-chart-graph-width);
           height: 100%;
+          /*
+          Move the chart over so that the trend lines
+          visually align with the charts above. We need
+          to do this because the svg element is a little wider
+          than the data inside it, because if we didn't,
+          the highlight dots would get clipped at either edge.
+          Related entries in this file are for
+            #runner--panel--modules {padding}
+          and
+            #runner--bottom {gap}
+          */
+          margin-left: calc(-1 * var(--pop-chart-highlight-dot-radius));
         }
 
         .trend {
@@ -893,17 +908,17 @@
         }
 
 
-        .labels {
-          transform: translate(5px, 0);
-          text {
-            font-size: 11px;
-            font-weight: 600;
-            fill: black;
-            opacity: 0.37;
-            transition: opacity 0.15s;
-            dominant-baseline: middle;
-          }
-        }
+        // .labels {
+        //   transform: translate(5px, 0);
+        //   text {
+        //     font-size: 11px;
+        //     font-weight: 600;
+        //     fill: black;
+        //     opacity: 0.37;
+        //     transition: opacity 0.15s;
+        //     dominant-baseline: middle;
+        //   }
+        // }
 
 
 
@@ -918,6 +933,7 @@
             stroke: none;
           }
           line {
+            display: none;
             stroke: var(--chart-graph-run-trend-stroke);
           }
         }
@@ -929,8 +945,9 @@
 
 
         .axis.y {
-          width: var(--pop-chart-yaxis-width);
+          width: calc(var(--pop-chart-yaxis-width) * 2);
           height: var(--trace-chart-width);
+          overflow: visible;
           // background-color: pink;
           line {
             stroke-width: 0.5;
@@ -942,9 +959,20 @@
             font-size: 11px;
             dominant-baseline: middle;
             text-anchor: start;
-            &.highlight {
-              fill: #094e77;
+          }
+          .hover {
+            .value {
+              font-size: 11px;
+              font-weight: 400;
             }
+            .label {
+              font-weight: 400;
+            }
+            &.median .value {
+              fill: #094e77;
+              font-weight: 600;
+            }
+
           }
         }
 
@@ -989,11 +1017,15 @@
 #runner--panel--modules {
   overflow: auto;
   height: calc(100% - 45px);
-}
-
-#runner--panel--other-modules {
-  display: none;
-  background-color: red;
+  /*
+  hack for gamma chart to visually align with
+  trend charts. See explanation at in this file
+  at
+    .population .chart .graph.display {margin-left}
+  and related is
+    #runner--bottom {gap}
+  */
+  padding: 0 0 0 var(--pop-chart-highlight-dot-radius);
 }
 
 

--- a/src/style/runner.less
+++ b/src/style/runner.less
@@ -907,25 +907,10 @@
           }
         }
 
-
-        // .labels {
-        //   transform: translate(5px, 0);
-        //   text {
-        //     font-size: 11px;
-        //     font-weight: 600;
-        //     fill: black;
-        //     opacity: 0.37;
-        //     transition: opacity 0.15s;
-        //     dominant-baseline: middle;
-        //   }
-        // }
-
-
-
-        // .dist {
-        //   fill: none;
-        //   stroke: var(--chart-graph-run-trend-stroke);
-        // }
+        .scrim {
+          fill: white;
+          fill-opacity: 0.6;
+        }
         .highlight {
           opacity: 0;
           ellipse {
@@ -936,6 +921,28 @@
             display: none;
             stroke: var(--chart-graph-run-trend-stroke);
           }
+          text {
+            font-size: 11px;
+            dominant-baseline: middle;
+            text-anchor: start;
+            fill: var(--chart-axis-text);
+            .value {
+              font-size: 11px;
+              font-weight: 400;
+            }
+            .label {
+              font-weight: 400;
+            }
+            &.median .value {
+              fill: #094e77;
+              font-weight: 600;
+            }
+          }
+
+          &.right text {
+            text-anchor: end;
+          }
+
         }
 
         line.highlight {
@@ -959,20 +966,6 @@
             font-size: 11px;
             dominant-baseline: middle;
             text-anchor: start;
-          }
-          .hover {
-            .value {
-              font-size: 11px;
-              font-weight: 400;
-            }
-            .label {
-              font-weight: 400;
-            }
-            &.median .value {
-              fill: #094e77;
-              font-weight: 600;
-            }
-
           }
         }
 

--- a/src/style/runner.less
+++ b/src/style/runner.less
@@ -710,9 +710,9 @@
 
       .bars {
         // opacity: 0.75;
-        .distribution {
-          // opacity: 0.375;
-        }
+        // .distribution {
+        //   // opacity: 0.375;
+        // }
         rect {
           // fill: var(--chart-histogram-bar-fill);
           fill: #c7c7c7;
@@ -1776,11 +1776,11 @@ label:has(#advanced-skygrid-toggle:checked) {
 
 
 
-.block.effective-population-size-log-scale .block--chart {
-  // canvas, canvas.kneed {
-  //   cursor: default;
-  // }
-}
+// .block.effective-population-size-log-scale .block--chart {
+//   // canvas, canvas.kneed {
+//   //   cursor: default;
+//   // }
+// }
 
 
 .y-axis,

--- a/src/style/runner.less
+++ b/src/style/runner.less
@@ -847,8 +847,14 @@
       max-width: var(--indicator-pop-module-width);
 
 
-      &.highlighting .chart .highlight {
-        opacity: 1;
+      &.highlighting .chart {
+        .labels {
+          opacity: 0;
+        }
+
+        .highlight {
+          opacity: 1;
+        }
       }
 
 
@@ -886,6 +892,21 @@
           }
         }
 
+
+        .labels {
+          transform: translate(5px, 0);
+          text {
+            font-size: 11px;
+            font-weight: 600;
+            fill: black;
+            opacity: 0.37;
+            transition: opacity 0.15s;
+            dominant-baseline: middle;
+          }
+        }
+
+
+
         // .dist {
         //   fill: none;
         //   stroke: var(--chart-graph-run-trend-stroke);
@@ -919,7 +940,7 @@
           }
           text {
             font-size: 11px;
-            alignment-baseline: middle;
+            dominant-baseline: middle;
             text-anchor: start;
             &.highlight {
               fill: #094e77;

--- a/src/style/runner.less
+++ b/src/style/runner.less
@@ -879,6 +879,20 @@
           }
         }
 
+        // .dist {
+        //   fill: none;
+        //   stroke: var(--chart-graph-run-trend-stroke);
+        // }
+        .highlight {
+          ellipse {
+            fill: var(--chart-graph-run-trend-stroke);
+            stroke: none;
+          }
+          line {
+            stroke: var(--chart-graph-run-trend-stroke);
+          }
+        }
+
 
         .axis.y {
           width: 37px;

--- a/src/ts/ui/common.ts
+++ b/src/ts/ui/common.ts
@@ -491,6 +491,13 @@ export function textIntersects(metrics1: MyTextMetrics, metrics2: MyTextMetrics)
 }
 
 export const UNSET = -1;
+/*
+for use in situations where UNSET (-1) falls
+within the valid range of inputs
+*/
+export const NO_VALUE = Number.MIN_SAFE_INTEGER;
+
+
 
 export type ZoomFnc = (vertZoom: number, vertScroll: number, horizZoom: number, horizScroll: number)=>void;
 

--- a/src/ts/ui/distribution.ts
+++ b/src/ts/ui/distribution.ts
@@ -150,6 +150,7 @@ export class Distribution {
 }
 
 
+/* calculate the 95% highest posterior density interval */
 export const calcHPD = (arr: number[])=>{
   const sorted = arr.slice(0).sort(numericSort);
   /* calculate the HPD */

--- a/src/ts/ui/runner/gammadata.ts
+++ b/src/ts/ui/runner/gammadata.ts
@@ -1,4 +1,3 @@
-import { toDateString } from '../../pythia/dates';
 import { log10, NO_VALUE, numericSort, UNSET } from '../common';
 import { calcHPD } from '../distribution';
 import { GammaDataFunction } from './runcommon';
@@ -134,7 +133,7 @@ export class GammaData extends TraceData {
     this._dateIndex = n;
     const pct = (n - this.minDate) / (this.maxDate - this.minDate);
     this._knotIndex = Math.round(pct * (this.dates.length - 1));
-    const date = this.dates[this._knotIndex];
+    // const date = this.dates[this._knotIndex];
     // console.log(n, toDateString(n), toDateString(this.minDate), toDateString(this.maxDate), toDateString(date), this.dates, this.knotStats[this._knotIndex]);
   }
 

--- a/src/ts/ui/runner/gammadata.ts
+++ b/src/ts/ui/runner/gammadata.ts
@@ -156,8 +156,13 @@ export class GammaData extends TraceData {
     let median: number,
       hpdMin: number,
       hpdMax: number;
-    if (lowerKnot === upperKnot) {
-      const knotData = this.knotStats[lowerKnot].slice(0);
+    /*
+    If we don't need to interpolate, then don't!
+    And if this is stepwise as opposed to log linear,
+    then we just take the values from the upper knot.
+    */
+    if (lowerKnot === upperKnot || !this.isLogLinear) {
+      const knotData = this.knotStats[upperKnot].slice(0);
       median = knotData[MEDIAN_INDEX];
       hpdMin = knotData[HPD_MIN_INDEX];
       hpdMax = knotData[HPD_MAX_INDEX];

--- a/src/ts/ui/runner/gammadata.ts
+++ b/src/ts/ui/runner/gammadata.ts
@@ -20,7 +20,7 @@ export class GammaData extends TraceData {
   rangeData: number[][] = [];
   postBurnin: number[][] = [];
   /* stores the median and 95% HPD for each knot */
-  converted: number[][] = [];
+  knotStats: number[][] = [];
   dates: number[] = [];
   isLogLinear = false;
   yearsMin: number = NO_VALUE;
@@ -48,8 +48,8 @@ export class GammaData extends TraceData {
     this.postBurnin.forEach((gamma, i)=>{
       gamma.forEach((g, k)=>byKnots[k][i] = g);
     });
-    this.converted = byKnots.map(hpdeify);
-    const safe = this.converted.flat().filter(n=>Number.isFinite(n));
+    this.knotStats = byKnots.map(hpdeify);
+    const safe = this.knotStats.flat().filter(n=>Number.isFinite(n));
 
     this.dataMin = Math.min(...safe);
     this.dataMax = Math.max(...safe);
@@ -107,6 +107,7 @@ export class GammaData extends TraceData {
       mag++;
       tens *= 10;
     }
+    console.log(this.logLabels)
 
 
   }
@@ -134,7 +135,7 @@ export class GammaData extends TraceData {
     const pct = (n - this.minDate) / (this.maxDate - this.minDate);
     this._knotIndex = Math.round(pct * (this.dates.length - 1));
     const date = this.dates[this._knotIndex];
-    console.log(n, toDateString(n), toDateString(this.minDate), toDateString(this.maxDate), toDateString(date), this.dates, this.converted[this._knotIndex]);
+    // console.log(n, toDateString(n), toDateString(this.minDate), toDateString(this.maxDate), toDateString(date), this.dates, this.knotStats[this._knotIndex]);
   }
 
   // get dateIndex() {

--- a/src/ts/ui/runner/gammadata.ts
+++ b/src/ts/ui/runner/gammadata.ts
@@ -1,3 +1,4 @@
+import { toFullDateString } from '../../pythia/dates';
 import { log10, NO_VALUE, numericSort, UNSET } from '../common';
 import { calcHPD, MEDIAN_INDEX, HPD_MIN_INDEX, HPD_MAX_INDEX } from '../distribution';
 import { GammaDataFunction } from './runcommon';
@@ -22,7 +23,9 @@ export type GammaHighlightDataType = {
   hpdMinY: number, // 0 (top) - 1 (bottom)
   hpdMax: number,
   hpdMaxY: number, // 0 (top) - 1 (bottom)
-  dateX: number    // 0 (left) - 1 (right)
+  dateIndex: number,
+  dateX: number,    // 0 (left) - 1 (right)
+  dateLabel: string
 };
 
 
@@ -40,8 +43,7 @@ export class GammaData extends TraceData {
   maxMagnitude: number = NO_VALUE;
   logRange: number = UNSET;
   logLabels: LogLabelType[] = [];
-  _dateIndex: number = NO_VALUE;
-  _knotIndex: number = NO_VALUE;
+  dateIndex: number = NO_VALUE;
   highlightData: GammaHighlightDataType | null = null;
 
   constructor(label:string, unit='', getDataFnc: GammaDataFunction) {
@@ -138,45 +140,45 @@ export class GammaData extends TraceData {
     return this.dates[this.dates.length-1];
   }
 
-  set dateIndex(n:number) {
-    if (n === NO_VALUE) {
-      this._knotIndex = NO_VALUE;
+  setDateIndex(dateIndex:number) : boolean {
+    const isUpdate = this.dateIndex !== dateIndex;
+    if (dateIndex === NO_VALUE) {
       this.highlightData = null;
-      return;
+      return isUpdate;
     }
-    this._dateIndex = n;
-    const pct = (n - this.minDate) / (this.maxDate - this.minDate);
-    this._knotIndex = Math.round(pct * (this.dates.length - 1));
-    // const date = this.dates[this._knotIndex];
-    // console.log(n, toDateString(n), toDateString(this.minDate), toDateString(this.maxDate), toDateString(date), this.dates, this.knotStats[this._knotIndex]);
-
-    const { displayMin, displayMax, dates } = this;
+    this.dateIndex = dateIndex;
+    const { displayMin, displayMax, minDate, maxDate, dates } = this;
+    const dateX = (dateIndex - minDate) / (maxDate - minDate);
     const range = displayMax - displayMin;
-    const firstDate = dates[0];
-    const lastDate = dates[dates.length - 1];
-    const dateRange = lastDate - firstDate;
-
-
-    const knotData = this.knotStats[this.knotIndex].slice(0);
-    const median = knotData[MEDIAN_INDEX];
-    const hpdMin = knotData[HPD_MIN_INDEX];
-    const hpdMax = knotData[HPD_MAX_INDEX];
+    const datePct = dateX * (dates.length - 1)
+    const lowerKnot = Math.floor(datePct);
+    const upperKnot = Math.ceil(datePct);
+    let median: number,
+      hpdMin: number,
+      hpdMax: number;
+    if (lowerKnot === upperKnot) {
+      const knotData = this.knotStats[lowerKnot].slice(0);
+      median = knotData[MEDIAN_INDEX];
+      hpdMin = knotData[HPD_MIN_INDEX];
+      hpdMax = knotData[HPD_MAX_INDEX];
+    } else {
+      const lowerData = this.knotStats[lowerKnot].slice(0);
+      const upperData = this.knotStats[upperKnot].slice(0);
+      const interpol = (datePct - lowerKnot) / (upperKnot - lowerKnot);
+      median = lowerData[MEDIAN_INDEX] + interpol * (upperData[MEDIAN_INDEX] - lowerData[MEDIAN_INDEX]);
+      hpdMin = lowerData[HPD_MIN_INDEX] + interpol * (upperData[HPD_MIN_INDEX] - lowerData[HPD_MIN_INDEX]);
+      hpdMax = lowerData[HPD_MAX_INDEX] + interpol * (upperData[HPD_MAX_INDEX] - lowerData[HPD_MAX_INDEX]);
+    }
     const medianY = 1-(median-displayMin) / range;
     const hpdMinY = 1-(hpdMin-displayMin) / range;
     const hpdMaxY = 1-(hpdMax-displayMin) / range;
-    const dateX = (n - firstDate) / dateRange;
-    this.highlightData = { median, medianY, hpdMin, hpdMinY, hpdMax, hpdMaxY, dateX };
 
-
+    const dateLabel = toFullDateString(dateIndex);
+    this.highlightData = { median, medianY, hpdMin, hpdMinY, hpdMax, hpdMaxY,
+      dateIndex, dateX, dateLabel };
+    return isUpdate;
   }
 
-  // get dateIndex() {
-  //   return this._dateIndex;
-  // }
-
-  get knotIndex() {
-    return this._knotIndex;
-  }
 
 }
 
@@ -193,7 +195,8 @@ const hpdeify = (arr:number[]):number[]=>{
   const sum = sorted.reduce((tot, n)=>tot+n, 0);
   const mean = sum / sorted.length;
   /*
-  must correspond to HPD_MIN_INDEX, HPD_MAX_INDEX, MEDIAN_INDEX, and MEAN_INDEX
+  must correspond to HPD_MIN_INDEX, HPD_MAX_INDEX, MEDIAN_INDEX,
+  (as defined in distribution.ts) and MEAN_INDEX (defined above)
   */
   return [hpdMin, hpdMax, median, mean];
 }

--- a/src/ts/ui/runner/gammadata.ts
+++ b/src/ts/ui/runner/gammadata.ts
@@ -1,4 +1,5 @@
-import { log10, numericSort, UNSET } from '../common';
+import { toDateString } from '../../pythia/dates';
+import { log10, NO_VALUE, numericSort, UNSET } from '../common';
 import { calcHPD } from '../distribution';
 import { GammaDataFunction } from './runcommon';
 import { TraceData } from './tracedata';
@@ -17,32 +18,34 @@ export type LogLabelType = {
 export class GammaData extends TraceData {
 
   rangeData: number[][] = [];
+  postBurnin: number[][] = [];
+  /* stores the median and 95% HPD for each knot */
   converted: number[][] = [];
   dates: number[] = [];
   isLogLinear = false;
-  highlightIndex: number = UNSET;
-  yearsMin: number = UNSET;
-  yearsMax: number = UNSET;
-  minMagnitude: number = UNSET;
-  maxMagnitude: number = UNSET;
+  yearsMin: number = NO_VALUE;
+  yearsMax: number = NO_VALUE;
+  minMagnitude: number = NO_VALUE;
+  maxMagnitude: number = NO_VALUE;
   logRange: number = UNSET;
   logLabels: LogLabelType[] = [];
+  _dateIndex: number = NO_VALUE;
+  _knotIndex: number = NO_VALUE;
 
   constructor(label:string, unit='', getDataFnc: GammaDataFunction) {
     super(label, unit, getDataFnc);
   }
 
-  setRangeData(data:number[][], dates: number[], isLogLinear: boolean, kneeIndex: number, sampleIndex: number):void {
+  setRangeData(data:number[][], dates: number[], isLogLinear: boolean, kneeIndex: number):void {
 
     this.rangeData = data;
     this.dates = dates;
     this.isLogLinear = isLogLinear;
     this.setKneeIndex(data.length, kneeIndex);
-    this.highlightIndex = sampleIndex;
-    const shown = this.savedKneeIndex > 0 ? data.slice(this.savedKneeIndex) : data;
+    this.postBurnin = this.savedKneeIndex > 0 ? data.slice(this.savedKneeIndex) : data;
     /* pivot the data to make arrays for every knot */
-    const byKnots:number[][] = shown[0].map(()=>new Array(shown.length));
-    shown.forEach((gamma, i)=>{
+    const byKnots:number[][] = this.postBurnin[0].map(()=>new Array(this.postBurnin.length));
+    this.postBurnin.forEach((gamma, i)=>{
       gamma.forEach((g, k)=>byKnots[k][i] = g);
     });
     this.converted = byKnots.map(hpdeify);
@@ -84,8 +87,8 @@ export class GammaData extends TraceData {
 
     while (mag < this.maxMagnitude) {
       const logLabel: LogLabelType = {
-        value: UNSET,
-        mag: UNSET,
+        value: NO_VALUE,
+        mag: NO_VALUE,
         ticks: []
       };
       this.logLabels.push(logLabel);
@@ -113,6 +116,34 @@ export class GammaData extends TraceData {
     return len;
   }
 
+
+  get minDate() : number {
+    return this.dates[0];
+  }
+
+  get maxDate() : number {
+    return this.dates[this.dates.length-1];
+  }
+
+  set dateIndex(n:number) {
+    if (n === NO_VALUE) {
+      this._knotIndex = NO_VALUE;
+      return;
+    }
+    this._dateIndex = n;
+    const pct = (n - this.minDate) / (this.maxDate - this.minDate);
+    this._knotIndex = Math.round(pct * (this.dates.length - 1));
+    const date = this.dates[this._knotIndex];
+    console.log(n, toDateString(n), toDateString(this.minDate), toDateString(this.maxDate), toDateString(date), this.dates, this.converted[this._knotIndex]);
+  }
+
+  // get dateIndex() {
+  //   return this._dateIndex;
+  // }
+
+  get knotIndex() {
+    return this._knotIndex;
+  }
 
 }
 

--- a/src/ts/ui/runner/gammadata.ts
+++ b/src/ts/ui/runner/gammadata.ts
@@ -1,16 +1,28 @@
 import { log10, NO_VALUE, numericSort, UNSET } from '../common';
-import { calcHPD } from '../distribution';
+import { calcHPD, MEDIAN_INDEX, HPD_MIN_INDEX, HPD_MAX_INDEX } from '../distribution';
 import { GammaDataFunction } from './runcommon';
 import { TraceData } from './tracedata';
 
-
+export const MEAN_INDEX = 3;
 const MIN_TICK_LENGTH = 4;
 const MAX_TICKS_FACTOR = 10 * 10 + MIN_TICK_LENGTH;
+
 
 export type LogLabelType = {
   value: number,
   mag: number,
   ticks: number[][]
+};
+
+
+export type GammaHighlightDataType = {
+  median: number,
+  medianY: number, // 0 (top) - 1 (bottom)
+  hpdMin: number,
+  hpdMinY: number, // 0 (top) - 1 (bottom)
+  hpdMax: number,
+  hpdMaxY: number, // 0 (top) - 1 (bottom)
+  dateX: number    // 0 (left) - 1 (right)
 };
 
 
@@ -30,6 +42,7 @@ export class GammaData extends TraceData {
   logLabels: LogLabelType[] = [];
   _dateIndex: number = NO_VALUE;
   _knotIndex: number = NO_VALUE;
+  highlightData: GammaHighlightDataType | null = null;
 
   constructor(label:string, unit='', getDataFnc: GammaDataFunction) {
     super(label, unit, getDataFnc);
@@ -128,6 +141,7 @@ export class GammaData extends TraceData {
   set dateIndex(n:number) {
     if (n === NO_VALUE) {
       this._knotIndex = NO_VALUE;
+      this.highlightData = null;
       return;
     }
     this._dateIndex = n;
@@ -135,6 +149,25 @@ export class GammaData extends TraceData {
     this._knotIndex = Math.round(pct * (this.dates.length - 1));
     // const date = this.dates[this._knotIndex];
     // console.log(n, toDateString(n), toDateString(this.minDate), toDateString(this.maxDate), toDateString(date), this.dates, this.knotStats[this._knotIndex]);
+
+    const { displayMin, displayMax, dates } = this;
+    const range = displayMax - displayMin;
+    const firstDate = dates[0];
+    const lastDate = dates[dates.length - 1];
+    const dateRange = lastDate - firstDate;
+
+
+    const knotData = this.knotStats[this.knotIndex].slice(0);
+    const median = knotData[MEDIAN_INDEX];
+    const hpdMin = knotData[HPD_MIN_INDEX];
+    const hpdMax = knotData[HPD_MAX_INDEX];
+    const medianY = 1-(median-displayMin) / range;
+    const hpdMinY = 1-(hpdMin-displayMin) / range;
+    const hpdMaxY = 1-(hpdMax-displayMin) / range;
+    const dateX = (n - firstDate) / dateRange;
+    this.highlightData = { median, medianY, hpdMin, hpdMinY, hpdMax, hpdMaxY, dateX };
+
+
   }
 
   // get dateIndex() {
@@ -159,8 +192,10 @@ const hpdeify = (arr:number[]):number[]=>{
   const [hpdMin, hpdMax, median] = calcHPD(sorted);
   const sum = sorted.reduce((tot, n)=>tot+n, 0);
   const mean = sum / sorted.length;
-  // console.log(hpdMin, hpdMax, mean)
-  return [hpdMin, hpdMax, mean, median];
+  /*
+  must correspond to HPD_MIN_INDEX, HPD_MAX_INDEX, MEDIAN_INDEX, and MEAN_INDEX
+  */
+  return [hpdMin, hpdMax, median, mean];
 }
 
 

--- a/src/ts/ui/runner/gammadata.ts
+++ b/src/ts/ui/runner/gammadata.ts
@@ -148,7 +148,7 @@ export class GammaData extends TraceData {
     }
     this.dateIndex = dateIndex;
     const { displayMin, displayMax, minDate, maxDate, dates } = this;
-    const dateX = (dateIndex - minDate) / (maxDate - minDate);
+    const dateX = Math.min(Math.max(0, (dateIndex - minDate) / (maxDate - minDate)), 1);
     const range = displayMax - displayMin;
     const datePct = dateX * (dates.length - 1)
     const lowerKnot = Math.max(0, Math.floor(datePct));

--- a/src/ts/ui/runner/gammadata.ts
+++ b/src/ts/ui/runner/gammadata.ts
@@ -151,8 +151,8 @@ export class GammaData extends TraceData {
     const dateX = (dateIndex - minDate) / (maxDate - minDate);
     const range = displayMax - displayMin;
     const datePct = dateX * (dates.length - 1)
-    const lowerKnot = Math.floor(datePct);
-    const upperKnot = Math.ceil(datePct);
+    const lowerKnot = Math.max(0, Math.floor(datePct));
+    const upperKnot = Math.min(dates.length - 1, Math.ceil(datePct));
     let median: number,
       hpdMin: number,
       hpdMax: number;

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -27,6 +27,7 @@ const PADDING = 3;
 const DATE_LABEL_WIDTH = 86;
 const HALF_DATE_LABEL_WIDTH = DATE_LABEL_WIDTH / 2;
 const POP_CHART_Y_AXIS_TEXT_RIGHT = 10;
+const POP_CHART_LABEL_WIDTH = 95;
 
 
 
@@ -248,7 +249,7 @@ export class GammaHistCanvas extends TraceCanvas {
       const positions: [number, number, number] = [hpdMinY, medianY, hpdMaxY];
       this.setLabelYSpacing(positions);
       const [hpdMinLabelY, medianLabelY, hpdMaxLabelY] = positions;
-      const rightAlign = dateX > this.width - DATE_LABEL_WIDTH;
+      const rightAlign = dateX > this.width - POP_CHART_LABEL_WIDTH;
       const textX = rightAlign ? - 4 : 4;
       let label = this.highlightG.querySelector(".hover.hpdmax") as SVGTextElement;
       label.setAttribute("x", `${textX}`);
@@ -269,10 +270,12 @@ export class GammaHistCanvas extends TraceCanvas {
       this.highlightG.setAttribute("transform", `translate(${dateX}, 0)`);
       if (rightAlign) {
         this.highlightG.classList.add("right");
+        this.scrim.setAttribute("x", `${dateX - this.width}`);
       } else {
         this.highlightG.classList.remove("right");
+        this.scrim.setAttribute("x", `${dateX}`);
       }
-      this.scrim.setAttribute("x", `${dateX}`);
+
       this.scrim.setAttribute("width", `${this.width}`);
       this.scrim.setAttribute("height", `${height}`);
       dateX = Math.min(Math.max(HALF_DATE_LABEL_WIDTH, dateX), this.width - HALF_DATE_LABEL_WIDTH);
@@ -284,7 +287,7 @@ export class GammaHistCanvas extends TraceCanvas {
     } else {
       this.container.classList.remove("highlighting");
       this.hoverSpan.textContent = '';
-      this.scrim.setAttribute("x", `${this.width}`);
+      // this.scrim.setAttribute("x", `${this.width}`);
     }
 
 

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -28,7 +28,7 @@ const PADDING = 3;
 
 const DATE_LABEL_WIDTH = 86;
 const HALF_DATE_LABEL_WIDTH = DATE_LABEL_WIDTH / 2;
-const POP_CHART_Y_AXIS_TEXT_RIGHT = 30;
+const POP_CHART_Y_AXIS_TEXT_RIGHT = 10;
 
 type highlightDataType = {
   median: number,
@@ -322,7 +322,7 @@ export class GammaHistCanvas extends TraceCanvas {
       /* label the top tick */
       this.addTick(0, (this.traceData as GammaData).getTickLength(9));
       if (!highlighting) {
-        this.addText(safeLabel(Math.pow(10, maxMagnitude), LOWER_OOM, UPPER_OOM), 0);
+        this.addText(`${safeLabel(Math.pow(10, maxMagnitude), LOWER_OOM, UPPER_OOM)} years`, 0);
       }
     }
 
@@ -393,7 +393,7 @@ export class GammaHistCanvas extends TraceCanvas {
     }
     textEle.textContent = label;
     textEle.classList.add("highlight");
-    textEle.setAttribute("x", `${ 10 }`);
+    textEle.setAttribute("x", `${ POP_CHART_Y_AXIS_TEXT_RIGHT }`);
     textEle.setAttribute("y", `${y}`);
     this.labelContainer.appendChild(textEle);
     return textEle;

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -288,7 +288,8 @@ export class GammaHistCanvas extends TraceCanvas {
 
   drawLabels():void {
     const { yAxisHeight, minSpan, maxSpan, height } = this;
-    const { logRange, maxMagnitude, minDate, maxDate, knotIndex, dates, knotStats: converted } = this.traceData as GammaData;
+    const { logRange, maxMagnitude, minDate, maxDate, knotIndex,
+      dates, knotStats, displayMin, displayMax } = this.traceData as GammaData;
     const labelHeight = LABEL_HEIGHT * logRange;
     const labelsOK = yAxisHeight >= labelHeight;
     // ctx.strokeStyle = 'black';
@@ -297,60 +298,54 @@ export class GammaHistCanvas extends TraceCanvas {
     let dateX = NO_VALUE;
     const highlighting = knotIndex !== NO_VALUE;
     this.labelContainer.innerHTML = '';
-    {
-      this.hoverSpan.textContent = '';
-      this.addTick(yAxisHeight, (this.traceData as GammaData).getTickLength(9));
-      const logLabels = (this.traceData as GammaData).logLabels;
-      logLabels.forEach((ll:LogLabelType)=>{
-        const { ticks, value } = ll;
-        ticks.forEach(([pct, tickLength], i)=>{
-          const y = yAxisHeight - pct * yAxisHeight;
-          const x2 = tickLength;
-          /* we don't want the tics to be so dense that they become a single shape */
-          if (labelsOK || i === 0 || i % 3 === 1) {
-            const tic = this.addTick(y, x2);
-            if (i === 0) {
-              tic.classList.add("on-mag");
-              if (!highlighting) {
-                this.addText(safeLabel(value), y);
-              }
+
+    this.hoverSpan.textContent = '';
+    this.addTick(yAxisHeight, (this.traceData as GammaData).getTickLength(9));
+    const logLabels = (this.traceData as GammaData).logLabels;
+    logLabels.forEach((ll:LogLabelType)=>{
+      const { ticks, value } = ll;
+      ticks.forEach(([pct, tickLength], i)=>{
+        const y = yAxisHeight - pct * yAxisHeight;
+        const x2 = tickLength;
+        /* we don't want the tics to be so dense that they become a single shape */
+        if (labelsOK || i === 0 || i % 3 === 1) {
+          const tic = this.addTick(y, x2);
+          if (i === 0) {
+            tic.classList.add("on-mag");
+            if (!highlighting) {
+              this.addText(safeLabel(value), y);
             }
           }
-        });
-
+        }
       });
-      /* label the top tick */
-      this.addTick(0, (this.traceData as GammaData).getTickLength(9));
-      if (!highlighting) {
-        this.addText(`${safeLabel(Math.pow(10, maxMagnitude), LOWER_OOM, UPPER_OOM)} years`, 0);
-      }
-    }
 
-    if (highlighting) {
-      let { medianY, hpdMinY, hpdMaxY } = this.highlightData;
+    });
+    /* label the top tick */
+    this.addTick(0, (this.traceData as GammaData).getTickLength(9));
+    if (!highlighting) {
+      this.addText(`${safeLabel(Math.pow(10, maxMagnitude), LOWER_OOM, UPPER_OOM)} years`, 0);
+      const valRange = displayMax - displayMin;
+      const verticalScale = height / (valRange || 1);
+      const firstKnot = knotStats[0].slice(0);
+      let medianY = height-(firstKnot[MEDIAN_INDEX]-displayMin) * verticalScale;
+      let hpdMinY = height-(firstKnot[MIN_HPD_INDEX]-displayMin) * verticalScale;
+      let hpdMaxY = height-(firstKnot[MAX_HPD_INDEX]-displayMin) * verticalScale;
+      const positions: [number, number, number] = [hpdMinY, medianY, hpdMaxY];
+      this.setLabelYSpacing(positions);
+      hpdMinY = positions[0];
+      medianY = positions[1];
+      hpdMaxY = positions[2];
+      (this.svg.querySelector(".labels .hpdmin") as SVGTextElement).setAttribute("y", `${hpdMinY}`);
+      (this.svg.querySelector(".labels .median") as SVGTextElement).setAttribute("y", `${medianY}`);
+      (this.svg.querySelector(".labels .hpdmax") as SVGTextElement).setAttribute("y", `${hpdMaxY}`);
+    } else {
       const { median, hpdMin, hpdMax } = this.highlightData;
       const dateIndex = dates[knotIndex];
-      const kWidth = this.dataWidth / (converted.length - 1);
+      const kWidth = this.dataWidth / (knotStats.length - 1);
       dateX = Math.min(Math.max(HALF_DATE_LABEL_WIDTH, PADDING + knotIndex * kWidth), this.width - HALF_DATE_LABEL_WIDTH);
-      if (medianY < LABEL_HEIGHT * 1.5) {
-        hpdMaxY = LABEL_HEIGHT * 0.5;
-        medianY = LABEL_HEIGHT * 1.5;
-      } else if (hpdMaxY - LABEL_HEIGHT / 2 < 0) {
-        hpdMaxY = LABEL_HEIGHT / 2;
-      }
-      if (medianY > height - LABEL_HEIGHT * 1.5) {
-        hpdMinY = height - LABEL_HEIGHT * 0.5;
-        medianY = height - LABEL_HEIGHT * 1.5;
-      } else if (hpdMinY > height - LABEL_HEIGHT * 0.5) {
-        hpdMinY = height - LABEL_HEIGHT * 0.5;
-      }
-      if (medianY - hpdMaxY < LABEL_HEIGHT) {
-        hpdMaxY = medianY - LABEL_HEIGHT;
-      }
-      if (hpdMinY - medianY < LABEL_HEIGHT) {
-        hpdMinY = medianY + LABEL_HEIGHT;
-      }
-
+      const positions: [number, number, number] = [this.highlightData.hpdMinY, this.highlightData.medianY, this.highlightData.hpdMaxY];
+      this.setLabelYSpacing(positions);
+      const [hpdMinY, medianY, hpdMaxY] = positions;
       this.addHighlightText(hpdMax, hpdMaxY, true);
       this.addHighlightText(median, medianY);
       this.addHighlightText(hpdMin, hpdMinY);
@@ -361,8 +356,35 @@ export class GammaHistCanvas extends TraceCanvas {
     maxSpan.textContent = toFullDateString(maxDate);
     minSpan.classList.toggle("hidden", dateX !== NO_VALUE && dateX <= DATE_LABEL_WIDTH * 1.5);
     maxSpan.classList.toggle("hidden", dateX >= this.width - DATE_LABEL_WIDTH * 1.5);
-
   }
+
+  /* Warning: modifies the values in the supplied array */
+  setLabelYSpacing(positions: [number, number, number]) : void {
+    let [hpdMinY, medianY, hpdMaxY] = positions;
+    const height = this.height;
+    if (medianY < LABEL_HEIGHT * 1.5) {
+      hpdMaxY = LABEL_HEIGHT * 0.5;
+      medianY = LABEL_HEIGHT * 1.5;
+    } else if (hpdMaxY - LABEL_HEIGHT / 2 < 0) {
+      hpdMaxY = LABEL_HEIGHT / 2;
+    }
+    if (medianY > height - LABEL_HEIGHT * 1.5) {
+      hpdMinY = height - LABEL_HEIGHT * 0.5;
+      medianY = height - LABEL_HEIGHT * 1.5;
+    } else if (hpdMinY > height - LABEL_HEIGHT * 0.5) {
+      hpdMinY = height - LABEL_HEIGHT * 0.5;
+    }
+    if (medianY - hpdMaxY < LABEL_HEIGHT) {
+      hpdMaxY = medianY - LABEL_HEIGHT;
+    }
+    if (hpdMinY - medianY < LABEL_HEIGHT) {
+      hpdMinY = medianY + LABEL_HEIGHT;
+    }
+    positions[0] = hpdMinY;
+    positions[1] = medianY;
+    positions[2] = hpdMaxY;
+  }
+
 
   addTick(y: number, x2: number) : SVGLineElement {
     const tick = this.labelTickTemplate.cloneNode(true) as SVGLineElement;

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -1,6 +1,6 @@
-import { toFullDateString } from "../../pythia/dates";
+import { toDateString, toFullDateString } from "../../pythia/dates";
 import { SkygridPopModel, SkygridPopModelType } from "../../pythia/delphy_api";
-import { safeLabel, UNSET } from "../common";
+import { getDateLabel, NO_VALUE, safeLabel, UNSET } from "../common";
 import { GammaData, LogLabelType } from "./gammadata";
 import { GammaDataFunction } from "./runcommon";
 import { chartContainer, TraceCanvas } from "./tracecanvas";
@@ -24,6 +24,9 @@ const LOWER_OOM = -2;
 const UPPER_OOM = 3;
 
 
+const PADDING = 3;
+
+
 export class GammaHistCanvas extends TraceCanvas {
 
   minSpan: HTMLDivElement;
@@ -31,11 +34,14 @@ export class GammaHistCanvas extends TraceCanvas {
   trendRange: SVGPathElement;
   medianTrend: SVGPathElement;
   sampleTrend: SVGPathElement;
+  // highlightDistribution: SVGPathElement;
+  highlightG: SVGGElement;
   labelContainer: SVGElement;
   labelTextTemplate: SVGTextElement;
   labelTickTemplate: SVGLineElement;
   yAxisWidth: number = UNSET;
   yAxisHeight: number = UNSET;
+  dataWidth: number = UNSET;
 
   constructor(label:string, getDataFnc: GammaDataFunction) {
     const className = label.toLowerCase().replace(/ /g, '-').replace(/[()<>]/g, '');
@@ -46,17 +52,35 @@ export class GammaHistCanvas extends TraceCanvas {
     this.trendRange = this.svg.querySelector(".trend.range") as SVGPathElement;
     this.medianTrend = this.svg.querySelector(".trend.median") as SVGPathElement;
     this.sampleTrend = this.svg.querySelector(".trend.sample") as SVGPathElement;
+    // this.highlightDistribution = this.svg.querySelector(".dist") as SVGPathElement;
+    this.highlightG = this.svg.querySelector(".highlight") as SVGGElement;
     this.labelContainer = this.container.querySelector(".chart .feature .axis.y svg.log-scale-ticks") as SVGElement;
     this.labelTextTemplate = this.labelContainer.querySelector("text") as SVGTextElement;
     this.labelTickTemplate = this.labelContainer.querySelector("line") as SVGLineElement;
+    const gammaData = this.traceData as GammaData;
+    this.svg.addEventListener('pointerenter', (event: PointerEvent)=>{
+      const xPct = event.offsetX / this.width;
+      gammaData.dateIndex = Math.round(gammaData.minDate + xPct * (gammaData.maxDate - gammaData.minDate));
+      requestAnimationFrame(()=>this.draw());
+    });
+    this.svg.addEventListener('pointermove', (event: PointerEvent)=>{
+      const xPct = event.offsetX / this.width;
+      gammaData.dateIndex = Math.round(gammaData.minDate + xPct * (gammaData.maxDate - gammaData.minDate));
+      requestAnimationFrame(()=>this.draw());
+    });
+    this.svg.addEventListener('pointerleave', (event: PointerEvent)=>{
+      gammaData.dateIndex = NO_VALUE;
+      requestAnimationFrame(()=>this.draw());
+    });
   }
 
   sizeCanvas() {
-    super.sizeCanvas();
     const wrapper = this.labelContainer.parentElement as HTMLDivElement;
     this.yAxisWidth = wrapper.offsetWidth;
     this.yAxisHeight = wrapper.offsetHeight;
-    requestAnimationFrame(()=>this.setSizes());
+    super.sizeCanvas();
+    this.dataWidth = this.width - 2 * PADDING;
+
   }
 
   protected setSizes(): void {
@@ -73,12 +97,12 @@ export class GammaHistCanvas extends TraceCanvas {
   //   (this.traceData as GammaData).setRangeData(data, dates, isLogLinear, kneeIndex, sampleIndex);
   // }
 
-  setRangeData(kneeIndex: number, sampleIndex: number):void {
+  setRangeData(kneeIndex: number):void {
     const popModelHist : SkygridPopModel[] = (this.traceData.getDataFnc as GammaDataFunction)();
     const gamma = popModelHist.map(popModel=>popModel.gamma);
     const xHist = popModelHist[0].x;
     const isLogLinear = popModelHist[0].type === SkygridPopModelType.LogLinear;
-    (this.traceData as GammaData).setRangeData(gamma, xHist, isLogLinear, kneeIndex, sampleIndex);
+    (this.traceData as GammaData).setRangeData(gamma, xHist, isLogLinear, kneeIndex);
   }
 
   handleTreeHighlight(treeIndex: number): void {
@@ -92,18 +116,19 @@ export class GammaHistCanvas extends TraceCanvas {
 
 
   drawRangeSeriesSVG():void {
-    const data:number[][] = (this.traceData as GammaData).converted;
-    if (data.length === 0) return;
-    const {height, width} = this;
+    const gammaData = (this.traceData as GammaData);
+    const {rangeData, sampleIndex, knotIndex, postBurnin, converted } = gammaData;
+    if (converted.length === 0) return;
+    const {height, dataWidth} = this;
     const {displayMin, displayMax} = this.traceData;
     const valRange = displayMax - displayMin;
     const verticalScale = height / (valRange || 1);
-    const kCount = data.length;
-    const kWidth = width / (kCount - 1);
+    const kCount = converted.length;
+    const kWidth = dataWidth / (kCount - 1);
     let i = 0;
-    let hpd = data[i][MIN_HPD_INDEX];
+    let hpd = converted[i][MIN_HPD_INDEX];
     const firstY = height-(hpd-displayMin) * verticalScale;
-    let x = 0;
+    let x = PADDING;
     let y = firstY;
 
     const drawingStaircase = !(this.traceData as GammaData).isLogLinear;
@@ -116,38 +141,37 @@ export class GammaHistCanvas extends TraceCanvas {
     // draw the 95% HPD area
     rangeD = `M${x} ${y} L`;
     for (i = 1; i < kCount; i++) {
-      hpd = data[i][MIN_HPD_INDEX];
+      hpd = converted[i][MIN_HPD_INDEX];
       y = height-(hpd-displayMin) * verticalScale;
       if (drawingStaircase) {
         rangeD += `${x} ${y} `;
       }
-      x = i * kWidth;
+      x = PADDING + i * kWidth;
       rangeD += `${x} ${y} `;
     }
     for (i = kCount - 1; i > 0; i--) {
-      x = i * kWidth;
-      hpd = data[i][MAX_HPD_INDEX];
+      x = PADDING + i * kWidth;
+      hpd = converted[i][MAX_HPD_INDEX];
       y = height-(hpd-displayMin) * verticalScale;
       rangeD += `${x} ${y} `;
       if (drawingStaircase) {
-        x = (i-1) * kWidth;
+        x = PADDING + (i-1) * kWidth;
         rangeD += `${x} ${y} `;
       }
     }
     if (!drawingStaircase) {
-      x = 0;
-      hpd = data[0][MAX_HPD_INDEX];
+      x = PADDING;
+      hpd = converted[0][MAX_HPD_INDEX];
       y = height-(hpd-displayMin) * verticalScale;
       rangeD += `${x} ${y} `;
     }
     rangeD += `${0} ${firstY} `;
 
     // draw the population curve for the current sample
-    const {rangeData, highlightIndex: sampleIndex } = (this.traceData as GammaData);
     if (sampleIndex !== UNSET) {
       const sampleData = rangeData[sampleIndex];
       console.assert(sampleData.length === kCount, "Current population curve has different number of points than mean curve?");
-      x = 0;
+      x = PADDING;
       y = height-(sampleData[0]-displayMin) * verticalScale;
       if (!drawingStaircase) {
         sampleD = `M${x} ${y} L`;
@@ -157,7 +181,7 @@ export class GammaHistCanvas extends TraceCanvas {
         if (drawingStaircase) {
           sampleD = `M${x} ${y} L`;
         }
-        x = i * kWidth;
+        x = PADDING + i * kWidth;
         sampleD += `${x} ${y} `;
       }
       this.sampleTrend.classList.remove("hidden");
@@ -167,19 +191,51 @@ export class GammaHistCanvas extends TraceCanvas {
     }
 
     // draw the median
-    let median = data[0][MEDIAN_INDEX];
-    x = 0;
+    let median = converted[0][MEDIAN_INDEX];
+    x = PADDING;
     y = height-(median-displayMin) * verticalScale;
     medianD = `M${x} ${y} L`;
     for (i = 1; i < kCount; i++) {
-      median = data[i][MEDIAN_INDEX];
+      median = converted[i][MEDIAN_INDEX];
       y = height-(median-displayMin) * verticalScale;
       if (drawingStaircase) {
         medianD = `M${x} ${y} L`;
       }
-      x = i * kWidth;
+      x = PADDING + i * kWidth;
       medianD += `${x} ${y} `;
     }
+
+    if (knotIndex !== NO_VALUE) {
+      // /* get all the samples at this time */
+      // const samples = postBurnin.map(treeData=>treeData[knotIndex]);
+      // const x1 = knotIndex * kWidth - 2;
+      // const x2 = x1 + 4;
+      // samples.forEach((value, i)=>{
+      //   const y = height-(value-displayMin) * verticalScale;
+      //   distD += `M${x1} ${y} L${x2} ${y}  `;
+      // });
+      /* get median and 95% HPD for this time / knot */
+      const x = PADDING + knotIndex * kWidth;
+      const knotData = converted[knotIndex]
+      const median = knotData[MEDIAN_INDEX];
+      const hpdMin = knotData[MIN_HPD_INDEX];
+      const hpdMax = knotData[MAX_HPD_INDEX];
+      const medianY = height-(median-displayMin) * verticalScale;
+      const hpdMinY = height-(hpdMin-displayMin) * verticalScale;
+      const hpdMaxY = height-(hpdMax-displayMin) * verticalScale;
+      const line = this.highlightG.querySelector("line") as SVGLineElement;
+      line.setAttribute("y1", `${hpdMinY}`);
+      line.setAttribute("y2", `${hpdMaxY}`);
+      (this.highlightG.querySelector(".hpdmin") as SVGEllipseElement).setAttribute("cy", `${hpdMinY}`);
+      (this.highlightG.querySelector(".median") as SVGEllipseElement).setAttribute("cy", `${medianY}`);
+      (this.highlightG.querySelector(".hpdmax") as SVGEllipseElement).setAttribute("cy", `${hpdMaxY}`);
+      this.highlightG.setAttribute("transform", `translate(${x}, 0)`);
+      this.container.classList.add("highlighting");
+      console.log(`     ${height}  ${hpdMinY}   ${medianY}   ${hpdMaxY}`);
+    } else {
+      this.container.classList.remove("highlighting");
+    }
+
 
     this.trendRange.setAttribute("d", rangeD);
     this.medianTrend.setAttribute("d", medianD);
@@ -187,11 +243,11 @@ export class GammaHistCanvas extends TraceCanvas {
 
 
   drawLabels():void {
-    const { yAxisWidth, yAxisHeight, minSpan, maxSpan} = this;
-    const {dates, logRange, maxMagnitude} = this.traceData as GammaData;
+    const { yAxisWidth, yAxisHeight, minSpan, maxSpan } = this;
+    const { logRange, maxMagnitude, minDate, maxDate } = this.traceData as GammaData;
     this.labelContainer.innerHTML = '';
-    minSpan.textContent = toFullDateString(dates[0])
-    maxSpan.textContent = toFullDateString(dates[dates.length - 1]);
+    minSpan.textContent = toFullDateString(minDate);
+    maxSpan.textContent = toFullDateString(maxDate);
     const labelHeight = LABEL_HEIGHT * logRange;
     const labelsOK = yAxisHeight >= labelHeight;
     // ctx.strokeStyle = 'black';

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -1,6 +1,6 @@
 import { toDateString, toFullDateString } from "../../pythia/dates";
 import { SkygridPopModel, SkygridPopModelType } from "../../pythia/delphy_api";
-import { getDateLabel, NO_VALUE, safeLabel, UNSET } from "../common";
+import { getDateLabel, NO_VALUE, numericSort, safeLabel, UNSET } from "../common";
 import { GammaData, LogLabelType } from "./gammadata";
 import { GammaDataFunction } from "./runcommon";
 import { chartContainer, TraceCanvas } from "./tracecanvas";
@@ -26,11 +26,26 @@ const UPPER_OOM = 3;
 
 const PADDING = 3;
 
+const DATE_LABEL_WIDTH = 86;
+const HALF_DATE_LABEL_WIDTH = DATE_LABEL_WIDTH / 2;
+const POP_CHART_Y_AXIS_TEXT_RIGHT = 30;
+
+type highlightDataType = {
+  median: number,
+  medianY: number,
+  hpdMin: number,
+  hpdMinY: number,
+  hpdMax: number,
+  hpdMaxY: number
+};
+
+
 
 export class GammaHistCanvas extends TraceCanvas {
 
   minSpan: HTMLDivElement;
   maxSpan: HTMLDivElement;
+  hoverSpan: HTMLDivElement;
   trendRange: SVGPathElement;
   medianTrend: SVGPathElement;
   sampleTrend: SVGPathElement;
@@ -42,6 +57,14 @@ export class GammaHistCanvas extends TraceCanvas {
   yAxisWidth: number = UNSET;
   yAxisHeight: number = UNSET;
   dataWidth: number = UNSET;
+  highlightData: highlightDataType = {
+    median: UNSET,
+    medianY: UNSET,
+    hpdMin: UNSET,
+    hpdMinY: UNSET,
+    hpdMax: UNSET,
+    hpdMaxY: UNSET
+  };
 
   constructor(label:string, getDataFnc: GammaDataFunction) {
     const className = label.toLowerCase().replace(/ /g, '-').replace(/[()<>]/g, '');
@@ -49,11 +72,12 @@ export class GammaHistCanvas extends TraceCanvas {
     this.traceData = new GammaData(label, '', getDataFnc);
     this.minSpan = this.container.querySelector(".support .axis.x .min-date") as HTMLDivElement;
     this.maxSpan = this.container.querySelector(".support .axis.x .max-date") as HTMLDivElement;
+    this.hoverSpan = this.container.querySelector(".support .axis.x .hover-date") as HTMLDivElement;
     this.trendRange = this.svg.querySelector(".trend.range") as SVGPathElement;
     this.medianTrend = this.svg.querySelector(".trend.median") as SVGPathElement;
     this.sampleTrend = this.svg.querySelector(".trend.sample") as SVGPathElement;
     // this.highlightDistribution = this.svg.querySelector(".dist") as SVGPathElement;
-    this.highlightG = this.svg.querySelector(".highlight") as SVGGElement;
+    this.highlightG = this.svg.querySelector("g.highlight") as SVGGElement;
     this.labelContainer = this.container.querySelector(".chart .feature .axis.y svg.log-scale-ticks") as SVGElement;
     this.labelTextTemplate = this.labelContainer.querySelector("text") as SVGTextElement;
     this.labelTickTemplate = this.labelContainer.querySelector("line") as SVGLineElement;
@@ -64,9 +88,12 @@ export class GammaHistCanvas extends TraceCanvas {
       requestAnimationFrame(()=>this.draw());
     });
     this.svg.addEventListener('pointermove', (event: PointerEvent)=>{
+      const old = gammaData.knotIndex;
       const xPct = event.offsetX / this.width;
       gammaData.dateIndex = Math.round(gammaData.minDate + xPct * (gammaData.maxDate - gammaData.minDate));
-      requestAnimationFrame(()=>this.draw());
+      if (old !== gammaData.knotIndex) {
+        requestAnimationFrame(()=>this.draw());
+      }
     });
     this.svg.addEventListener('pointerleave', (event: PointerEvent)=>{
       gammaData.dateIndex = NO_VALUE;
@@ -117,7 +144,7 @@ export class GammaHistCanvas extends TraceCanvas {
 
   drawRangeSeriesSVG():void {
     const gammaData = (this.traceData as GammaData);
-    const {rangeData, sampleIndex, knotIndex, postBurnin, converted } = gammaData;
+    const {rangeData, sampleIndex, knotIndex, postBurnin, knotStats: converted } = gammaData;
     if (converted.length === 0) return;
     const {height, dataWidth} = this;
     const {displayMin, displayMax} = this.traceData;
@@ -165,7 +192,7 @@ export class GammaHistCanvas extends TraceCanvas {
       y = height-(hpd-displayMin) * verticalScale;
       rangeD += `${x} ${y} `;
     }
-    rangeD += `${0} ${firstY} `;
+    rangeD += `${PADDING} ${firstY} `;
 
     // draw the population curve for the current sample
     if (sampleIndex !== UNSET) {
@@ -216,22 +243,39 @@ export class GammaHistCanvas extends TraceCanvas {
       // });
       /* get median and 95% HPD for this time / knot */
       const x = PADDING + knotIndex * kWidth;
-      const knotData = converted[knotIndex]
+      const knotData = converted[knotIndex].slice(0);
       const median = knotData[MEDIAN_INDEX];
       const hpdMin = knotData[MIN_HPD_INDEX];
       const hpdMax = knotData[MAX_HPD_INDEX];
       const medianY = height-(median-displayMin) * verticalScale;
       const hpdMinY = height-(hpdMin-displayMin) * verticalScale;
       const hpdMaxY = height-(hpdMax-displayMin) * verticalScale;
-      const line = this.highlightG.querySelector("line") as SVGLineElement;
+      this.highlightData = { median, medianY, hpdMin, hpdMinY, hpdMax, hpdMaxY };
+      let line = this.highlightG.querySelector(".dist") as SVGLineElement;
       line.setAttribute("y1", `${hpdMinY}`);
       line.setAttribute("y2", `${hpdMaxY}`);
-      (this.highlightG.querySelector(".hpdmin") as SVGEllipseElement).setAttribute("cy", `${hpdMinY}`);
-      (this.highlightG.querySelector(".median") as SVGEllipseElement).setAttribute("cy", `${medianY}`);
-      (this.highlightG.querySelector(".hpdmax") as SVGEllipseElement).setAttribute("cy", `${hpdMaxY}`);
+      line = this.svg.querySelector(".marker.hpdmin") as SVGLineElement;
+      line.setAttribute("x1", `${PADDING}`);
+      line.setAttribute("x2", `${this.width - PADDING}`);
+      line.setAttribute("y1", `${hpdMinY}`);
+      line.setAttribute("y2", `${hpdMinY}`);
+      line = this.svg.querySelector(".marker.median") as SVGLineElement;
+      line.setAttribute("x1", `${PADDING}`);
+      line.setAttribute("x2", `${this.width - PADDING}`);
+      line.setAttribute("y1", `${medianY}`);
+      line.setAttribute("y2", `${medianY}`);
+      line = this.svg.querySelector(".marker.hpdmax") as SVGLineElement;
+      line.setAttribute("x1", `${PADDING}`);
+      line.setAttribute("x2", `${this.width - PADDING}`);
+      line.setAttribute("y1", `${hpdMaxY}`);
+      line.setAttribute("y2", `${hpdMaxY}`);
+
+      (this.highlightG.querySelector(".point.hpdmin") as SVGEllipseElement).setAttribute("cy", `${hpdMinY}`);
+      (this.highlightG.querySelector(".point.median") as SVGEllipseElement).setAttribute("cy", `${medianY}`);
+      (this.highlightG.querySelector(".point.hpdmax") as SVGEllipseElement).setAttribute("cy", `${hpdMaxY}`);
       this.highlightG.setAttribute("transform", `translate(${x}, 0)`);
       this.container.classList.add("highlighting");
-      console.log(`     ${height}  ${hpdMinY}   ${medianY}   ${hpdMaxY}`);
+      console.log(knotIndex, knotData);
     } else {
       this.container.classList.remove("highlighting");
     }
@@ -243,43 +287,86 @@ export class GammaHistCanvas extends TraceCanvas {
 
 
   drawLabels():void {
-    const { yAxisWidth, yAxisHeight, minSpan, maxSpan } = this;
-    const { logRange, maxMagnitude, minDate, maxDate } = this.traceData as GammaData;
-    this.labelContainer.innerHTML = '';
-    minSpan.textContent = toFullDateString(minDate);
-    maxSpan.textContent = toFullDateString(maxDate);
+    const { yAxisHeight, minSpan, maxSpan, height } = this;
+    const { logRange, maxMagnitude, minDate, maxDate, knotIndex, dates, knotStats: converted } = this.traceData as GammaData;
     const labelHeight = LABEL_HEIGHT * logRange;
     const labelsOK = yAxisHeight >= labelHeight;
     // ctx.strokeStyle = 'black';
     // ctx.lineWidth = 0;
     // ctx.beginPath();
-
-    this.addTick(yAxisHeight, (this.traceData as GammaData).getTickLength(9));
-    const logLabels = (this.traceData as GammaData).logLabels;
-    logLabels.forEach((ll:LogLabelType)=>{
-      const { ticks, value } = ll;
-      ticks.forEach(([pct, tickLength], i)=>{
-        const y = yAxisHeight - pct * yAxisHeight;
-        const x2 = yAxisWidth - tickLength;
-        /* we don't want the tics to be so dense that they become a single shape */
-        if (labelsOK || i === 0 || i % 3 === 1) {
-          const tic = this.addTick(y, x2);
-          if (i === 0) {
-            tic.classList.add("on-mag");
-            this.addText(safeLabel(value), y);
+    let dateX = NO_VALUE;
+    const highlighting = knotIndex !== NO_VALUE;
+    this.labelContainer.innerHTML = '';
+    {
+      this.hoverSpan.textContent = '';
+      this.addTick(yAxisHeight, (this.traceData as GammaData).getTickLength(9));
+      const logLabels = (this.traceData as GammaData).logLabels;
+      logLabels.forEach((ll:LogLabelType)=>{
+        const { ticks, value } = ll;
+        ticks.forEach(([pct, tickLength], i)=>{
+          const y = yAxisHeight - pct * yAxisHeight;
+          const x2 = tickLength;
+          /* we don't want the tics to be so dense that they become a single shape */
+          if (labelsOK || i === 0 || i % 3 === 1) {
+            const tic = this.addTick(y, x2);
+            if (i === 0) {
+              tic.classList.add("on-mag");
+              if (!highlighting) {
+                this.addText(safeLabel(value), y);
+              }
+            }
           }
-        }
-      });
+        });
 
-    });
-    /* label the top tick */
-    this.addTick(0, (this.traceData as GammaData).getTickLength(9));
-    this.addText(safeLabel(Math.pow(10, maxMagnitude), LOWER_OOM, UPPER_OOM), 0);
+      });
+      /* label the top tick */
+      this.addTick(0, (this.traceData as GammaData).getTickLength(9));
+      if (!highlighting) {
+        this.addText(safeLabel(Math.pow(10, maxMagnitude), LOWER_OOM, UPPER_OOM), 0);
+      }
+    }
+
+    if (highlighting) {
+      let { medianY, hpdMinY, hpdMaxY } = this.highlightData;
+      const { median, hpdMin, hpdMax } = this.highlightData;
+      const dateIndex = dates[knotIndex];
+      const kWidth = this.dataWidth / (converted.length - 1);
+      dateX = Math.min(Math.max(HALF_DATE_LABEL_WIDTH, PADDING + knotIndex * kWidth), this.width - HALF_DATE_LABEL_WIDTH);
+      if (medianY < LABEL_HEIGHT * 1.5) {
+        hpdMaxY = LABEL_HEIGHT * 0.5;
+        medianY = LABEL_HEIGHT * 1.5;
+      } else if (hpdMaxY - LABEL_HEIGHT / 2 < 0) {
+        hpdMaxY = LABEL_HEIGHT / 2;
+      }
+      if (medianY > height - LABEL_HEIGHT * 1.5) {
+        hpdMinY = height - LABEL_HEIGHT * 0.5;
+        medianY = height - LABEL_HEIGHT * 1.5;
+      } else if (hpdMinY > height - LABEL_HEIGHT * 0.5) {
+        hpdMinY = height - LABEL_HEIGHT * 0.5;
+      }
+      if (medianY - hpdMaxY < LABEL_HEIGHT) {
+        hpdMaxY = medianY - LABEL_HEIGHT;
+      }
+      if (hpdMinY - medianY < LABEL_HEIGHT) {
+        hpdMinY = medianY + LABEL_HEIGHT;
+      }
+
+      this.addHighlightText(hpdMax, hpdMaxY, true);
+      this.addHighlightText(median, medianY);
+      this.addHighlightText(hpdMin, hpdMinY);
+      this.hoverSpan.textContent = toFullDateString(dateIndex);
+      this.hoverSpan.style.left = `${dateX}px`;
+    }
+    minSpan.textContent = toFullDateString(minDate);
+    maxSpan.textContent = toFullDateString(maxDate);
+    minSpan.classList.toggle("hidden", dateX !== NO_VALUE && dateX <= DATE_LABEL_WIDTH * 1.5);
+    maxSpan.classList.toggle("hidden", dateX >= this.width - DATE_LABEL_WIDTH * 1.5);
+
   }
 
   addTick(y: number, x2: number) : SVGLineElement {
     const tick = this.labelTickTemplate.cloneNode(true) as SVGLineElement;
-    tick.setAttribute("x1", `${ this.yAxisWidth }`);
+    tick.setAttribute("x1", `${ 0 }`);
     tick.setAttribute("y1", `${ y }`);
     tick.setAttribute("x2", `${ x2 }`);
     tick.setAttribute("y2", `${ y }`);
@@ -290,7 +377,23 @@ export class GammaHistCanvas extends TraceCanvas {
   addText(text: string, y: number): SVGTextElement {
     const textEle = this.labelTextTemplate.cloneNode(true) as SVGTextElement;
     textEle.textContent = text;
-    textEle.setAttribute("x", `${ this.yAxisWidth - 12 }`);
+    textEle.setAttribute("x", `${ POP_CHART_Y_AXIS_TEXT_RIGHT }`);
+    textEle.setAttribute("y", `${y}`);
+    this.labelContainer.appendChild(textEle);
+    return textEle;
+  }
+
+
+  addHighlightText(value: number, y: number, showUnit=false) : SVGTextElement {
+    const scaledValue = Math.exp(value) / 365;
+    const textEle = this.labelTextTemplate.cloneNode(true) as SVGTextElement;
+    let label = `${ safeLabel(scaledValue)}`;
+    if (showUnit) {
+      label += ' years';
+    }
+    textEle.textContent = label;
+    textEle.classList.add("highlight");
+    textEle.setAttribute("x", `${ 10 }`);
     textEle.setAttribute("y", `${y}`);
     this.labelContainer.appendChild(textEle);
     return textEle;

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -1,7 +1,8 @@
 import { toFullDateString } from "../../pythia/dates";
 import { SkygridPopModel, SkygridPopModelType } from "../../pythia/delphy_api";
 import { NO_VALUE, safeLabel, UNSET } from "../common";
-import { GammaData, LogLabelType } from "./gammadata";
+import { MEDIAN_INDEX, HPD_MIN_INDEX, HPD_MAX_INDEX } from "../distribution";
+import { GammaData, GammaHighlightDataType, LogLabelType } from "./gammadata";
 import { GammaDataFunction } from "./runcommon";
 import { chartContainer, TraceCanvas } from "./tracecanvas";
 
@@ -15,9 +16,6 @@ const Y_AXIS_OVERFLOW = 10;
 
 const LABEL_HEIGHT = 14;
 
-const MIN_HPD_INDEX = 0;
-const MAX_HPD_INDEX = 1;
-const MEDIAN_INDEX = 3;
 
 
 const LOWER_OOM = -2;
@@ -30,14 +28,7 @@ const DATE_LABEL_WIDTH = 86;
 const HALF_DATE_LABEL_WIDTH = DATE_LABEL_WIDTH / 2;
 const POP_CHART_Y_AXIS_TEXT_RIGHT = 10;
 
-type highlightDataType = {
-  median: number,
-  medianY: number,
-  hpdMin: number,
-  hpdMinY: number,
-  hpdMax: number,
-  hpdMaxY: number
-};
+
 
 
 
@@ -58,14 +49,6 @@ export class GammaHistCanvas extends TraceCanvas {
   yAxisWidth: number = UNSET;
   yAxisHeight: number = UNSET;
   dataWidth: number = UNSET;
-  highlightData: highlightDataType = {
-    median: UNSET,
-    medianY: UNSET,
-    hpdMin: UNSET,
-    hpdMinY: UNSET,
-    hpdMax: UNSET,
-    hpdMaxY: UNSET
-  };
 
   constructor(label:string, subtitle: string, className: string, getDataFnc: GammaDataFunction) {
     if (className === '') {
@@ -152,7 +135,7 @@ export class GammaHistCanvas extends TraceCanvas {
 
   drawRangeSeriesSVG():void {
     const gammaData = (this.traceData as GammaData);
-    const {rangeData, sampleIndex, knotIndex, knotStats } = gammaData;
+    const {rangeData, sampleIndex, knotIndex, knotStats, highlightData } = gammaData;
     if (knotStats.length === 0) return;
     const {height, dataWidth} = this;
     const {displayMin, displayMax} = this.traceData;
@@ -161,7 +144,7 @@ export class GammaHistCanvas extends TraceCanvas {
     const kCount = knotStats.length;
     const kWidth = dataWidth / (kCount - 1);
     let i = 0;
-    let hpd = knotStats[i][MIN_HPD_INDEX];
+    let hpd = knotStats[i][HPD_MIN_INDEX];
     const firstY = height-(hpd-displayMin) * verticalScale;
     let x = PADDING;
     let y = firstY;
@@ -178,7 +161,7 @@ export class GammaHistCanvas extends TraceCanvas {
     // draw the 95% HPD area
     rangeD = `M${x} ${y} L`;
     for (i = 1; i < kCount; i++) {
-      hpd = knotStats[i][MIN_HPD_INDEX];
+      hpd = knotStats[i][HPD_MIN_INDEX];
       y = height-(hpd-displayMin) * verticalScale;
       if (drawingStaircase) {
         rangeD += `${x} ${y} `;
@@ -188,7 +171,7 @@ export class GammaHistCanvas extends TraceCanvas {
     }
     for (i = kCount - 1; i > 0; i--) {
       x = PADDING + i * kWidth;
-      hpd = knotStats[i][MAX_HPD_INDEX];
+      hpd = knotStats[i][HPD_MAX_INDEX];
       y = height-(hpd-displayMin) * verticalScale;
       rangeD += `${x} ${y} `;
       if (drawingStaircase) {
@@ -198,7 +181,7 @@ export class GammaHistCanvas extends TraceCanvas {
     }
     if (!drawingStaircase) {
       x = PADDING;
-      hpd = knotStats[0][MAX_HPD_INDEX];
+      hpd = knotStats[0][HPD_MAX_INDEX];
       y = height-(hpd-displayMin) * verticalScale;
       rangeD += `${x} ${y} `;
     }
@@ -242,7 +225,7 @@ export class GammaHistCanvas extends TraceCanvas {
       medianD += `${x} ${y} `;
     }
 
-    if (knotIndex !== NO_VALUE) {
+    if (highlightData !== null) {
       // /* get all the samples at this time */
       // const samples = postBurnin.map(treeData=>treeData[knotIndex]);
       // const x1 = knotIndex * kWidth - 2;
@@ -252,15 +235,12 @@ export class GammaHistCanvas extends TraceCanvas {
       //   distD += `M${x1} ${y} L${x2} ${y}  `;
       // });
       /* get median and 95% HPD for this time / knot */
-      const x = PADDING + knotIndex * kWidth;
-      const knotData = knotStats[knotIndex].slice(0);
-      const median = knotData[MEDIAN_INDEX];
-      const hpdMin = knotData[MIN_HPD_INDEX];
-      const hpdMax = knotData[MAX_HPD_INDEX];
-      const medianY = height-(median-displayMin) * verticalScale;
-      const hpdMinY = height-(hpdMin-displayMin) * verticalScale;
-      const hpdMaxY = height-(hpdMax-displayMin) * verticalScale;
-      this.highlightData = { median, medianY, hpdMin, hpdMinY, hpdMax, hpdMaxY };
+      let { medianY, hpdMinY, hpdMaxY, dateX } = highlightData;
+      medianY *= height;
+      hpdMinY *= height;
+      hpdMaxY *= height;
+      dateX *= this.width;
+
       let line = this.highlightG.querySelector(".dist") as SVGLineElement;
       line.setAttribute("y1", `${hpdMinY}`);
       line.setAttribute("y2", `${hpdMaxY}`);
@@ -283,11 +263,10 @@ export class GammaHistCanvas extends TraceCanvas {
       (this.highlightG.querySelector(".point.hpdmin") as SVGEllipseElement).setAttribute("cy", `${hpdMinY}`);
       (this.highlightG.querySelector(".point.median") as SVGEllipseElement).setAttribute("cy", `${medianY}`);
       (this.highlightG.querySelector(".point.hpdmax") as SVGEllipseElement).setAttribute("cy", `${hpdMaxY}`);
-      this.highlightG.setAttribute("transform", `translate(${x}, 0)`);
+      this.highlightG.setAttribute("transform", `translate(${dateX}, 0)`);
       this.container.classList.add("highlighting");
-      console.log(knotIndex, knotData);
     } else {
-      this.container.classList.remove("highlighting");
+      // this.container.classList.remove("highlighting");
     }
 
 
@@ -299,7 +278,7 @@ export class GammaHistCanvas extends TraceCanvas {
   drawLabels():void {
     const { yAxisHeight, minSpan, maxSpan, height } = this;
     const { logRange, maxMagnitude, minDate, maxDate, knotIndex,
-      dates, knotStats, displayMin, displayMax } = this.traceData as GammaData;
+      dates, highlightData } = this.traceData as GammaData;
     const labelHeight = LABEL_HEIGHT * logRange;
     const labelsOK = yAxisHeight >= labelHeight;
     // ctx.strokeStyle = 'black';
@@ -332,14 +311,14 @@ export class GammaHistCanvas extends TraceCanvas {
     });
     /* label the top tick */
     this.addTick(0, (this.traceData as GammaData).getTickLength(9));
-    if (!highlighting) {
+    if (highlightData === null) {
       this.addText(`${safeLabel(Math.pow(10, maxMagnitude), LOWER_OOM, UPPER_OOM)} years`, 0);
       // const valRange = displayMax - displayMin;
       // const verticalScale = height / (valRange || 1);
       // const firstKnot = knotStats[0].slice(0);
       // let medianY = height-(firstKnot[MEDIAN_INDEX]-displayMin) * verticalScale;
-      // let hpdMinY = height-(firstKnot[MIN_HPD_INDEX]-displayMin) * verticalScale;
-      // let hpdMaxY = height-(firstKnot[MAX_HPD_INDEX]-displayMin) * verticalScale;
+      // let hpdMinY = height-(firstKnot[HPD_MIN_INDEX]-displayMin) * verticalScale;
+      // let hpdMaxY = height-(firstKnot[HPD_MAX_INDEX]-displayMin) * verticalScale;
       // const positions: [number, number, number] = [hpdMinY, medianY, hpdMaxY];
       // this.setLabelYSpacing(positions);
       // hpdMinY = positions[0];
@@ -349,11 +328,14 @@ export class GammaHistCanvas extends TraceCanvas {
       // (this.svg.querySelector(".labels .median") as SVGTextElement).setAttribute("y", `${medianY}`);
       // (this.svg.querySelector(".labels .hpdmax") as SVGTextElement).setAttribute("y", `${hpdMaxY}`);
     } else {
-      const { median, hpdMin, hpdMax } = this.highlightData;
+      const { median, hpdMin, hpdMax } = highlightData;
       const dateIndex = dates[knotIndex];
-      const kWidth = this.dataWidth / (knotStats.length - 1);
-      dateX = Math.min(Math.max(HALF_DATE_LABEL_WIDTH, PADDING + knotIndex * kWidth), this.width - HALF_DATE_LABEL_WIDTH);
-      const positions: [number, number, number] = [this.highlightData.hpdMinY, this.highlightData.medianY, this.highlightData.hpdMaxY];
+      dateX = PADDING + highlightData.dateX * this.width;
+      dateX = Math.min(Math.max(HALF_DATE_LABEL_WIDTH, dateX), this.width - HALF_DATE_LABEL_WIDTH);
+      const positions: [number, number, number] = [
+        highlightData.hpdMinY * height,
+        highlightData.medianY * height,
+        highlightData.hpdMaxY * height];
       this.setLabelYSpacing(positions);
       const [hpdMinY, medianY, hpdMaxY] = positions;
       this.addHighlightText(hpdMax, hpdMaxY, "max");

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -2,7 +2,7 @@ import { toFullDateString } from "../../pythia/dates";
 import { SkygridPopModel, SkygridPopModelType } from "../../pythia/delphy_api";
 import { NO_VALUE, safeLabel, UNSET } from "../common";
 import { MEDIAN_INDEX, HPD_MIN_INDEX, HPD_MAX_INDEX } from "../distribution";
-import { GammaData, GammaHighlightDataType, LogLabelType } from "./gammadata";
+import { GammaData, LogLabelType } from "./gammadata";
 import { GammaDataFunction } from "./runcommon";
 import { chartContainer, TraceCanvas } from "./tracecanvas";
 
@@ -75,19 +75,19 @@ export class GammaHistCanvas extends TraceCanvas {
     const gammaData = this.traceData as GammaData;
     this.svg.addEventListener('pointerenter', (event: PointerEvent)=>{
       const xPct = event.offsetX / this.width;
-      gammaData.dateIndex = Math.round(gammaData.minDate + xPct * (gammaData.maxDate - gammaData.minDate));
+      const dateIndex = Math.round(gammaData.minDate + xPct * (gammaData.maxDate - gammaData.minDate));
+      gammaData.setDateIndex(dateIndex);
       requestAnimationFrame(()=>this.draw());
     });
     this.svg.addEventListener('pointermove', (event: PointerEvent)=>{
-      const old = gammaData.knotIndex;
       const xPct = event.offsetX / this.width;
-      gammaData.dateIndex = Math.round(gammaData.minDate + xPct * (gammaData.maxDate - gammaData.minDate));
-      if (old !== gammaData.knotIndex) {
+      const dateIndex = Math.round(gammaData.minDate + xPct * (gammaData.maxDate - gammaData.minDate));
+      if (gammaData.setDateIndex(dateIndex)) {
         requestAnimationFrame(()=>this.draw());
       }
     });
     this.svg.addEventListener('pointerleave', ()=>{
-      gammaData.dateIndex = NO_VALUE;
+      gammaData.setDateIndex(NO_VALUE);
       requestAnimationFrame(()=>this.draw());
     });
   }
@@ -135,7 +135,7 @@ export class GammaHistCanvas extends TraceCanvas {
 
   drawRangeSeriesSVG():void {
     const gammaData = (this.traceData as GammaData);
-    const {rangeData, sampleIndex, knotIndex, knotStats, highlightData } = gammaData;
+    const {rangeData, sampleIndex, knotStats, highlightData } = gammaData;
     if (knotStats.length === 0) return;
     const {height, dataWidth} = this;
     const {displayMin, displayMax} = this.traceData;
@@ -266,7 +266,7 @@ export class GammaHistCanvas extends TraceCanvas {
       this.highlightG.setAttribute("transform", `translate(${dateX}, 0)`);
       this.container.classList.add("highlighting");
     } else {
-      // this.container.classList.remove("highlighting");
+      this.container.classList.remove("highlighting");
     }
 
 
@@ -277,15 +277,15 @@ export class GammaHistCanvas extends TraceCanvas {
 
   drawLabels():void {
     const { yAxisHeight, minSpan, maxSpan, height } = this;
-    const { logRange, maxMagnitude, minDate, maxDate, knotIndex,
-      dates, highlightData } = this.traceData as GammaData;
+    const { logRange, maxMagnitude, minDate, maxDate,
+      highlightData } = this.traceData as GammaData;
     const labelHeight = LABEL_HEIGHT * logRange;
     const labelsOK = yAxisHeight >= labelHeight;
     // ctx.strokeStyle = 'black';
     // ctx.lineWidth = 0;
     // ctx.beginPath();
     let dateX = NO_VALUE;
-    const highlighting = knotIndex !== NO_VALUE;
+    const highlighting = highlightData !== null;
     this.labelContainer.innerHTML = '';
 
     this.hoverSpan.textContent = '';
@@ -328,8 +328,7 @@ export class GammaHistCanvas extends TraceCanvas {
       // (this.svg.querySelector(".labels .median") as SVGTextElement).setAttribute("y", `${medianY}`);
       // (this.svg.querySelector(".labels .hpdmax") as SVGTextElement).setAttribute("y", `${hpdMaxY}`);
     } else {
-      const { median, hpdMin, hpdMax } = highlightData;
-      const dateIndex = dates[knotIndex];
+      const { median, hpdMin, hpdMax, dateLabel } = highlightData;
       dateX = PADDING + highlightData.dateX * this.width;
       dateX = Math.min(Math.max(HALF_DATE_LABEL_WIDTH, dateX), this.width - HALF_DATE_LABEL_WIDTH);
       const positions: [number, number, number] = [
@@ -341,7 +340,7 @@ export class GammaHistCanvas extends TraceCanvas {
       this.addHighlightText(hpdMax, hpdMaxY, "max");
       this.addHighlightText(median, medianY, "median");
       this.addHighlightText(hpdMin, hpdMinY, "min");
-      this.hoverSpan.textContent = toFullDateString(dateIndex);
+      this.hoverSpan.textContent = dateLabel;
       this.hoverSpan.style.left = `${dateX}px`;
     }
     minSpan.textContent = toFullDateString(minDate);

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -199,7 +199,7 @@ export class GammaHistCanvas extends TraceCanvas {
       for (i = 1; i < kCount; i++) {
         y = height-(sampleData[i]-displayMin) * verticalScale;
         if (drawingStaircase) {
-          sampleD = `M${x} ${y} L`;
+          sampleD += `M${x} ${y} L`;
         }
         x = PADDING + i * kWidth;
         sampleD += `${x} ${y} `;
@@ -214,12 +214,14 @@ export class GammaHistCanvas extends TraceCanvas {
     let median = knotStats[0][MEDIAN_INDEX];
     x = PADDING;
     y = height-(median-displayMin) * verticalScale;
-    medianD = `M${x} ${y} L`;
+    if (!drawingStaircase) {
+      medianD = `M${x} ${y} L`;
+    }
     for (i = 1; i < kCount; i++) {
       median = knotStats[i][MEDIAN_INDEX];
       y = height-(median-displayMin) * verticalScale;
       if (drawingStaircase) {
-        medianD = `M${x} ${y} L`;
+        medianD += `M${x} ${y} L`;
       }
       x = PADDING + i * kWidth;
       medianD += `${x} ${y} `;

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -54,6 +54,7 @@ export class GammaHistCanvas extends TraceCanvas {
   labelContainer: SVGElement;
   labelTextTemplate: SVGTextElement;
   labelTickTemplate: SVGLineElement;
+  hoverLabelTemplate: SVGTextElement;
   yAxisWidth: number = UNSET;
   yAxisHeight: number = UNSET;
   dataWidth: number = UNSET;
@@ -66,9 +67,14 @@ export class GammaHistCanvas extends TraceCanvas {
     hpdMaxY: UNSET
   };
 
-  constructor(label:string, getDataFnc: GammaDataFunction) {
-    const className = label.toLowerCase().replace(/ /g, '-').replace(/[()<>]/g, '');
+  constructor(label:string, subtitle: string, className: string, getDataFnc: GammaDataFunction) {
+    if (className === '') {
+      className = label.toLowerCase().replace(/ /g, '-').replace(/[()<>]/g, '');
+    }
     super(label, '', className, getDataFnc, POP_TEMPLATE);
+    if (subtitle !== '') {
+      (this.container.querySelector(".header .subtitle") as HTMLParagraphElement).innerHTML = subtitle;
+    }
     this.traceData = new GammaData(label, '', getDataFnc);
     this.minSpan = this.container.querySelector(".support .axis.x .min-date") as HTMLDivElement;
     this.maxSpan = this.container.querySelector(".support .axis.x .max-date") as HTMLDivElement;
@@ -79,8 +85,10 @@ export class GammaHistCanvas extends TraceCanvas {
     // this.highlightDistribution = this.svg.querySelector(".dist") as SVGPathElement;
     this.highlightG = this.svg.querySelector("g.highlight") as SVGGElement;
     this.labelContainer = this.container.querySelector(".chart .feature .axis.y svg.log-scale-ticks") as SVGElement;
-    this.labelTextTemplate = this.labelContainer.querySelector("text") as SVGTextElement;
+    this.labelTextTemplate = this.labelContainer.querySelector(".tick") as SVGTextElement;
     this.labelTickTemplate = this.labelContainer.querySelector("line") as SVGLineElement;
+    this.hoverLabelTemplate = this.labelContainer.querySelector(".hover") as SVGTextElement;
+    this.hoverLabelTemplate.remove();
     const gammaData = this.traceData as GammaData;
     this.svg.addEventListener('pointerenter', (event: PointerEvent)=>{
       const xPct = event.offsetX / this.width;
@@ -157,6 +165,8 @@ export class GammaHistCanvas extends TraceCanvas {
     const firstY = height-(hpd-displayMin) * verticalScale;
     let x = PADDING;
     let y = firstY;
+
+
 
     const drawingStaircase = !(this.traceData as GammaData).isLogLinear;
 
@@ -277,7 +287,7 @@ export class GammaHistCanvas extends TraceCanvas {
       this.container.classList.add("highlighting");
       console.log(knotIndex, knotData);
     } else {
-      this.container.classList.remove("highlighting");
+      // this.container.classList.remove("highlighting");
     }
 
 
@@ -324,20 +334,20 @@ export class GammaHistCanvas extends TraceCanvas {
     this.addTick(0, (this.traceData as GammaData).getTickLength(9));
     if (!highlighting) {
       this.addText(`${safeLabel(Math.pow(10, maxMagnitude), LOWER_OOM, UPPER_OOM)} years`, 0);
-      const valRange = displayMax - displayMin;
-      const verticalScale = height / (valRange || 1);
-      const firstKnot = knotStats[0].slice(0);
-      let medianY = height-(firstKnot[MEDIAN_INDEX]-displayMin) * verticalScale;
-      let hpdMinY = height-(firstKnot[MIN_HPD_INDEX]-displayMin) * verticalScale;
-      let hpdMaxY = height-(firstKnot[MAX_HPD_INDEX]-displayMin) * verticalScale;
-      const positions: [number, number, number] = [hpdMinY, medianY, hpdMaxY];
-      this.setLabelYSpacing(positions);
-      hpdMinY = positions[0];
-      medianY = positions[1];
-      hpdMaxY = positions[2];
-      (this.svg.querySelector(".labels .hpdmin") as SVGTextElement).setAttribute("y", `${hpdMinY}`);
-      (this.svg.querySelector(".labels .median") as SVGTextElement).setAttribute("y", `${medianY}`);
-      (this.svg.querySelector(".labels .hpdmax") as SVGTextElement).setAttribute("y", `${hpdMaxY}`);
+      // const valRange = displayMax - displayMin;
+      // const verticalScale = height / (valRange || 1);
+      // const firstKnot = knotStats[0].slice(0);
+      // let medianY = height-(firstKnot[MEDIAN_INDEX]-displayMin) * verticalScale;
+      // let hpdMinY = height-(firstKnot[MIN_HPD_INDEX]-displayMin) * verticalScale;
+      // let hpdMaxY = height-(firstKnot[MAX_HPD_INDEX]-displayMin) * verticalScale;
+      // const positions: [number, number, number] = [hpdMinY, medianY, hpdMaxY];
+      // this.setLabelYSpacing(positions);
+      // hpdMinY = positions[0];
+      // medianY = positions[1];
+      // hpdMaxY = positions[2];
+      // (this.svg.querySelector(".labels .hpdmin") as SVGTextElement).setAttribute("y", `${hpdMinY}`);
+      // (this.svg.querySelector(".labels .median") as SVGTextElement).setAttribute("y", `${medianY}`);
+      // (this.svg.querySelector(".labels .hpdmax") as SVGTextElement).setAttribute("y", `${hpdMaxY}`);
     } else {
       const { median, hpdMin, hpdMax } = this.highlightData;
       const dateIndex = dates[knotIndex];
@@ -346,9 +356,9 @@ export class GammaHistCanvas extends TraceCanvas {
       const positions: [number, number, number] = [this.highlightData.hpdMinY, this.highlightData.medianY, this.highlightData.hpdMaxY];
       this.setLabelYSpacing(positions);
       const [hpdMinY, medianY, hpdMaxY] = positions;
-      this.addHighlightText(hpdMax, hpdMaxY, true);
-      this.addHighlightText(median, medianY);
-      this.addHighlightText(hpdMin, hpdMinY);
+      this.addHighlightText(hpdMax, hpdMaxY, "max");
+      this.addHighlightText(median, medianY, "median");
+      this.addHighlightText(hpdMin, hpdMinY, "min");
       this.hoverSpan.textContent = toFullDateString(dateIndex);
       this.hoverSpan.style.left = `${dateX}px`;
     }
@@ -406,15 +416,13 @@ export class GammaHistCanvas extends TraceCanvas {
   }
 
 
-  addHighlightText(value: number, y: number, showUnit=false) : SVGTextElement {
+  addHighlightText(value: number, y: number, stat: string) : SVGTextElement {
     const scaledValue = Math.exp(value) / 365;
-    const textEle = this.labelTextTemplate.cloneNode(true) as SVGTextElement;
-    let label = `${ safeLabel(scaledValue)}`;
-    if (showUnit) {
-      label += ' years';
-    }
-    textEle.textContent = label;
-    textEle.classList.add("highlight");
+    const textEle = this.hoverLabelTemplate.cloneNode(true) as SVGTextElement;
+    const label = `${ safeLabel(scaledValue)} years`;
+    (textEle.querySelector(".value") as SVGTSpanElement).textContent = label;
+    (textEle.querySelector(".label") as SVGTSpanElement).textContent = ` ${stat}`;
+    textEle.classList.add(stat);
     textEle.setAttribute("x", `${ POP_CHART_Y_AXIS_TEXT_RIGHT }`);
     textEle.setAttribute("y", `${y}`);
     this.labelContainer.appendChild(textEle);

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -1,6 +1,6 @@
-import { toDateString, toFullDateString } from "../../pythia/dates";
+import { toFullDateString } from "../../pythia/dates";
 import { SkygridPopModel, SkygridPopModelType } from "../../pythia/delphy_api";
-import { getDateLabel, NO_VALUE, numericSort, safeLabel, UNSET } from "../common";
+import { NO_VALUE, safeLabel, UNSET } from "../common";
 import { GammaData, LogLabelType } from "./gammadata";
 import { GammaDataFunction } from "./runcommon";
 import { chartContainer, TraceCanvas } from "./tracecanvas";
@@ -95,7 +95,7 @@ export class GammaHistCanvas extends TraceCanvas {
         requestAnimationFrame(()=>this.draw());
       }
     });
-    this.svg.addEventListener('pointerleave', (event: PointerEvent)=>{
+    this.svg.addEventListener('pointerleave', ()=>{
       gammaData.dateIndex = NO_VALUE;
       requestAnimationFrame(()=>this.draw());
     });
@@ -144,16 +144,16 @@ export class GammaHistCanvas extends TraceCanvas {
 
   drawRangeSeriesSVG():void {
     const gammaData = (this.traceData as GammaData);
-    const {rangeData, sampleIndex, knotIndex, postBurnin, knotStats: converted } = gammaData;
-    if (converted.length === 0) return;
+    const {rangeData, sampleIndex, knotIndex, knotStats } = gammaData;
+    if (knotStats.length === 0) return;
     const {height, dataWidth} = this;
     const {displayMin, displayMax} = this.traceData;
     const valRange = displayMax - displayMin;
     const verticalScale = height / (valRange || 1);
-    const kCount = converted.length;
+    const kCount = knotStats.length;
     const kWidth = dataWidth / (kCount - 1);
     let i = 0;
-    let hpd = converted[i][MIN_HPD_INDEX];
+    let hpd = knotStats[i][MIN_HPD_INDEX];
     const firstY = height-(hpd-displayMin) * verticalScale;
     let x = PADDING;
     let y = firstY;
@@ -168,7 +168,7 @@ export class GammaHistCanvas extends TraceCanvas {
     // draw the 95% HPD area
     rangeD = `M${x} ${y} L`;
     for (i = 1; i < kCount; i++) {
-      hpd = converted[i][MIN_HPD_INDEX];
+      hpd = knotStats[i][MIN_HPD_INDEX];
       y = height-(hpd-displayMin) * verticalScale;
       if (drawingStaircase) {
         rangeD += `${x} ${y} `;
@@ -178,7 +178,7 @@ export class GammaHistCanvas extends TraceCanvas {
     }
     for (i = kCount - 1; i > 0; i--) {
       x = PADDING + i * kWidth;
-      hpd = converted[i][MAX_HPD_INDEX];
+      hpd = knotStats[i][MAX_HPD_INDEX];
       y = height-(hpd-displayMin) * verticalScale;
       rangeD += `${x} ${y} `;
       if (drawingStaircase) {
@@ -188,7 +188,7 @@ export class GammaHistCanvas extends TraceCanvas {
     }
     if (!drawingStaircase) {
       x = PADDING;
-      hpd = converted[0][MAX_HPD_INDEX];
+      hpd = knotStats[0][MAX_HPD_INDEX];
       y = height-(hpd-displayMin) * verticalScale;
       rangeD += `${x} ${y} `;
     }
@@ -218,12 +218,12 @@ export class GammaHistCanvas extends TraceCanvas {
     }
 
     // draw the median
-    let median = converted[0][MEDIAN_INDEX];
+    let median = knotStats[0][MEDIAN_INDEX];
     x = PADDING;
     y = height-(median-displayMin) * verticalScale;
     medianD = `M${x} ${y} L`;
     for (i = 1; i < kCount; i++) {
-      median = converted[i][MEDIAN_INDEX];
+      median = knotStats[i][MEDIAN_INDEX];
       y = height-(median-displayMin) * verticalScale;
       if (drawingStaircase) {
         medianD = `M${x} ${y} L`;
@@ -243,7 +243,7 @@ export class GammaHistCanvas extends TraceCanvas {
       // });
       /* get median and 95% HPD for this time / knot */
       const x = PADDING + knotIndex * kWidth;
-      const knotData = converted[knotIndex].slice(0);
+      const knotData = knotStats[knotIndex].slice(0);
       const median = knotData[MEDIAN_INDEX];
       const hpdMin = knotData[MIN_HPD_INDEX];
       const hpdMax = knotData[MAX_HPD_INDEX];

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -287,7 +287,7 @@ export class GammaHistCanvas extends TraceCanvas {
       this.container.classList.add("highlighting");
       console.log(knotIndex, knotData);
     } else {
-      // this.container.classList.remove("highlighting");
+      this.container.classList.remove("highlighting");
     }
 
 

--- a/src/ts/ui/runner/gammahistcanvas.ts
+++ b/src/ts/ui/runner/gammahistcanvas.ts
@@ -45,7 +45,8 @@ export class GammaHistCanvas extends TraceCanvas {
   labelContainer: SVGElement;
   labelTextTemplate: SVGTextElement;
   labelTickTemplate: SVGLineElement;
-  hoverLabelTemplate: SVGTextElement;
+  // hoverLabelTemplate: SVGTextElement;
+  scrim: SVGRectElement;
   yAxisWidth: number = UNSET;
   yAxisHeight: number = UNSET;
   dataWidth: number = UNSET;
@@ -70,8 +71,9 @@ export class GammaHistCanvas extends TraceCanvas {
     this.labelContainer = this.container.querySelector(".chart .feature .axis.y svg.log-scale-ticks") as SVGElement;
     this.labelTextTemplate = this.labelContainer.querySelector(".tick") as SVGTextElement;
     this.labelTickTemplate = this.labelContainer.querySelector("line") as SVGLineElement;
-    this.hoverLabelTemplate = this.labelContainer.querySelector(".hover") as SVGTextElement;
-    this.hoverLabelTemplate.remove();
+    // this.hoverLabelTemplate = this.labelContainer.querySelector(".hover") as SVGTextElement;
+    // this.hoverLabelTemplate.remove();
+    this.scrim = this.svg.querySelector(".scrim") as SVGRectElement;
     const gammaData = this.traceData as GammaData;
     this.svg.addEventListener('pointerenter', (event: PointerEvent)=>{
       const xPct = event.offsetX / this.width;
@@ -242,33 +244,47 @@ export class GammaHistCanvas extends TraceCanvas {
       hpdMinY *= height;
       hpdMaxY *= height;
       dateX *= this.width;
-
-      let line = this.highlightG.querySelector(".dist") as SVGLineElement;
-      line.setAttribute("y1", `${hpdMinY}`);
-      line.setAttribute("y2", `${hpdMaxY}`);
-      line = this.svg.querySelector(".marker.hpdmin") as SVGLineElement;
-      line.setAttribute("x1", `${PADDING}`);
-      line.setAttribute("x2", `${this.width - PADDING}`);
-      line.setAttribute("y1", `${hpdMinY}`);
-      line.setAttribute("y2", `${hpdMinY}`);
-      line = this.svg.querySelector(".marker.median") as SVGLineElement;
-      line.setAttribute("x1", `${PADDING}`);
-      line.setAttribute("x2", `${this.width - PADDING}`);
-      line.setAttribute("y1", `${medianY}`);
-      line.setAttribute("y2", `${medianY}`);
-      line = this.svg.querySelector(".marker.hpdmax") as SVGLineElement;
-      line.setAttribute("x1", `${PADDING}`);
-      line.setAttribute("x2", `${this.width - PADDING}`);
-      line.setAttribute("y1", `${hpdMaxY}`);
-      line.setAttribute("y2", `${hpdMaxY}`);
-
+      const { median, hpdMin, hpdMax, dateLabel } = highlightData;
+      const positions: [number, number, number] = [hpdMinY, medianY, hpdMaxY];
+      this.setLabelYSpacing(positions);
+      const [hpdMinLabelY, medianLabelY, hpdMaxLabelY] = positions;
+      const rightAlign = dateX > this.width - DATE_LABEL_WIDTH;
+      const textX = rightAlign ? - 4 : 4;
+      let label = this.highlightG.querySelector(".hover.hpdmax") as SVGTextElement;
+      label.setAttribute("x", `${textX}`);
+      label.setAttribute("y", `${hpdMaxLabelY}`);
+      (label.querySelector(".value") as SVGTSpanElement).textContent = `${safeLabel(hpdMax)} years`;
+      label = this.highlightG.querySelector(".hover.median") as SVGTextElement;
+      label.setAttribute("x", `${textX}`);
+      label.setAttribute("y", `${medianLabelY}`);
+      (label.querySelector(".value") as SVGTSpanElement).textContent = `${safeLabel(median)} years`;
+      label = this.highlightG.querySelector(".hover.hpdmin") as SVGTextElement;
+      label.setAttribute("x", `${textX}`);
+      label.setAttribute("y", `${hpdMinLabelY}`);
+      (label.querySelector(".value") as SVGTSpanElement).textContent = `${safeLabel(hpdMin)} years`;
+      dateX = PADDING + highlightData.dateX * (this.width - PADDING * 2);
       (this.highlightG.querySelector(".point.hpdmin") as SVGEllipseElement).setAttribute("cy", `${hpdMinY}`);
       (this.highlightG.querySelector(".point.median") as SVGEllipseElement).setAttribute("cy", `${medianY}`);
       (this.highlightG.querySelector(".point.hpdmax") as SVGEllipseElement).setAttribute("cy", `${hpdMaxY}`);
       this.highlightG.setAttribute("transform", `translate(${dateX}, 0)`);
+      if (rightAlign) {
+        this.highlightG.classList.add("right");
+      } else {
+        this.highlightG.classList.remove("right");
+      }
+      this.scrim.setAttribute("x", `${dateX}`);
+      this.scrim.setAttribute("width", `${this.width}`);
+      this.scrim.setAttribute("height", `${height}`);
+      dateX = Math.min(Math.max(HALF_DATE_LABEL_WIDTH, dateX), this.width - HALF_DATE_LABEL_WIDTH);
+      this.hoverSpan.textContent = dateLabel;
+      this.hoverSpan.style.left = `${dateX}px`;
+      this.minSpan.classList.toggle("hidden", dateX !== NO_VALUE && dateX <= DATE_LABEL_WIDTH * 1.5);
+      this.maxSpan.classList.toggle("hidden", dateX >= this.width - DATE_LABEL_WIDTH * 1.5);
       this.container.classList.add("highlighting");
     } else {
       this.container.classList.remove("highlighting");
+      this.hoverSpan.textContent = '';
+      this.scrim.setAttribute("x", `${this.width}`);
     }
 
 
@@ -278,19 +294,13 @@ export class GammaHistCanvas extends TraceCanvas {
 
 
   drawLabels():void {
-    const { yAxisHeight, minSpan, maxSpan, height } = this;
-    const { logRange, maxMagnitude, minDate, maxDate,
-      highlightData } = this.traceData as GammaData;
+    const { yAxisHeight, minSpan, maxSpan } = this;
+    const { logRange, maxMagnitude, minDate, maxDate } = this.traceData as GammaData;
     const labelHeight = LABEL_HEIGHT * logRange;
     const labelsOK = yAxisHeight >= labelHeight;
-    // ctx.strokeStyle = 'black';
-    // ctx.lineWidth = 0;
-    // ctx.beginPath();
-    let dateX = NO_VALUE;
-    const highlighting = highlightData !== null;
+    const dateX = NO_VALUE;
     this.labelContainer.innerHTML = '';
 
-    this.hoverSpan.textContent = '';
     this.addTick(yAxisHeight, (this.traceData as GammaData).getTickLength(9));
     const logLabels = (this.traceData as GammaData).logLabels;
     logLabels.forEach((ll:LogLabelType)=>{
@@ -303,9 +313,7 @@ export class GammaHistCanvas extends TraceCanvas {
           const tic = this.addTick(y, x2);
           if (i === 0) {
             tic.classList.add("on-mag");
-            if (!highlighting) {
-              this.addText(safeLabel(value), y);
-            }
+            this.addText(safeLabel(value), y);
           }
         }
       });
@@ -313,42 +321,9 @@ export class GammaHistCanvas extends TraceCanvas {
     });
     /* label the top tick */
     this.addTick(0, (this.traceData as GammaData).getTickLength(9));
-    if (highlightData === null) {
-      this.addText(`${safeLabel(Math.pow(10, maxMagnitude), LOWER_OOM, UPPER_OOM)} years`, 0);
-      // const valRange = displayMax - displayMin;
-      // const verticalScale = height / (valRange || 1);
-      // const firstKnot = knotStats[0].slice(0);
-      // let medianY = height-(firstKnot[MEDIAN_INDEX]-displayMin) * verticalScale;
-      // let hpdMinY = height-(firstKnot[HPD_MIN_INDEX]-displayMin) * verticalScale;
-      // let hpdMaxY = height-(firstKnot[HPD_MAX_INDEX]-displayMin) * verticalScale;
-      // const positions: [number, number, number] = [hpdMinY, medianY, hpdMaxY];
-      // this.setLabelYSpacing(positions);
-      // hpdMinY = positions[0];
-      // medianY = positions[1];
-      // hpdMaxY = positions[2];
-      // (this.svg.querySelector(".labels .hpdmin") as SVGTextElement).setAttribute("y", `${hpdMinY}`);
-      // (this.svg.querySelector(".labels .median") as SVGTextElement).setAttribute("y", `${medianY}`);
-      // (this.svg.querySelector(".labels .hpdmax") as SVGTextElement).setAttribute("y", `${hpdMaxY}`);
-    } else {
-      const { median, hpdMin, hpdMax, dateLabel } = highlightData;
-      dateX = PADDING + highlightData.dateX * this.width;
-      dateX = Math.min(Math.max(HALF_DATE_LABEL_WIDTH, dateX), this.width - HALF_DATE_LABEL_WIDTH);
-      const positions: [number, number, number] = [
-        highlightData.hpdMinY * height,
-        highlightData.medianY * height,
-        highlightData.hpdMaxY * height];
-      this.setLabelYSpacing(positions);
-      const [hpdMinY, medianY, hpdMaxY] = positions;
-      this.addHighlightText(hpdMax, hpdMaxY, "max");
-      this.addHighlightText(median, medianY, "median");
-      this.addHighlightText(hpdMin, hpdMinY, "min");
-      this.hoverSpan.textContent = dateLabel;
-      this.hoverSpan.style.left = `${dateX}px`;
-    }
+    this.addText(`${safeLabel(Math.pow(10, maxMagnitude), LOWER_OOM, UPPER_OOM)} years`, 0);
     minSpan.textContent = toFullDateString(minDate);
     maxSpan.textContent = toFullDateString(maxDate);
-    minSpan.classList.toggle("hidden", dateX !== NO_VALUE && dateX <= DATE_LABEL_WIDTH * 1.5);
-    maxSpan.classList.toggle("hidden", dateX >= this.width - DATE_LABEL_WIDTH * 1.5);
   }
 
   /* Warning: modifies the values in the supplied array */
@@ -399,18 +374,18 @@ export class GammaHistCanvas extends TraceCanvas {
   }
 
 
-  addHighlightText(value: number, y: number, stat: string) : SVGTextElement {
-    const scaledValue = Math.exp(value) / 365;
-    const textEle = this.hoverLabelTemplate.cloneNode(true) as SVGTextElement;
-    const label = `${ safeLabel(scaledValue)} years`;
-    (textEle.querySelector(".value") as SVGTSpanElement).textContent = label;
-    (textEle.querySelector(".label") as SVGTSpanElement).textContent = ` ${stat}`;
-    textEle.classList.add(stat);
-    textEle.setAttribute("x", `${ POP_CHART_Y_AXIS_TEXT_RIGHT }`);
-    textEle.setAttribute("y", `${y}`);
-    this.labelContainer.appendChild(textEle);
-    return textEle;
-  }
+  // addHighlightText(value: number, y: number, stat: string) : SVGTextElement {
+  //   const scaledValue = Math.exp(value) / 365;
+  //   const textEle = this.hoverLabelTemplate.cloneNode(true) as SVGTextElement;
+  //   const label = `${ safeLabel(scaledValue)} years`;
+  //   (textEle.querySelector(".value") as SVGTSpanElement).textContent = label;
+  //   (textEle.querySelector(".label") as SVGTSpanElement).textContent = ` ${stat}`;
+  //   textEle.classList.add(stat);
+  //   textEle.setAttribute("x", `${ POP_CHART_Y_AXIS_TEXT_RIGHT }`);
+  //   textEle.setAttribute("y", `${y}`);
+  //   this.labelContainer.appendChild(textEle);
+  //   return textEle;
+  // }
 
 }
 

--- a/src/ts/ui/runner/histcanvas.ts
+++ b/src/ts/ui/runner/histcanvas.ts
@@ -1,5 +1,5 @@
 import { downloadTextFile, getDecimalPrecision, getPercentLabelDecimal, getTimestampString,
-  nf000, nfc, nicenum, safeLabel, UNSET } from '../common';
+  nf000, nfc, nicenum, NO_VALUE, safeLabel, UNSET } from '../common';
 import { chartContainer, TraceCanvas } from "./tracecanvas";
 import { HistDataFunction, hoverListenerType, kneeHoverListenerType, PlottableSummaryStats,
   statHoverListenerType, SummaryStat, SummaryStatLongLabels, SummaryStatLookup, SummaryStatsType } from './runcommon';
@@ -28,13 +28,6 @@ TICK_BAR_TEMPLATE.remove();
 
 const MAX_STEP_SIZE = 3;
 const TARGET_LABEL_SPACING = 70; // in px
-
-/*
-for use in situations where UNSET (-1) falls
-within the valid range of inputs
-*/
-const NO_VALUE = Number.MIN_SAFE_INTEGER;
-
 
 export class HistCanvas extends TraceCanvas {
 
@@ -133,7 +126,7 @@ export class HistCanvas extends TraceCanvas {
     });
     this.histoSVG.addEventListener('pointermove', (event: PointerEvent)=>this.handleHistogramHover(event));
     this.histoSVG.addEventListener('pointerleave', ()=>{
-      this.traceData.highlightIndex = UNSET;
+      this.traceData.sampleIndex = UNSET;
       const binConfig = (this.traceData as HistData).binConfig;
       if (binConfig.isHistogram) {
         this.drawHistogramSVG(NO_VALUE);
@@ -320,7 +313,7 @@ export class HistCanvas extends TraceCanvas {
 
   handleTreeHighlight(treeIndex: number): void {
     const traceData = this.traceData as HistData;
-    traceData.highlightIndex = treeIndex;
+    traceData.sampleIndex = treeIndex;
   }
 
 
@@ -365,7 +358,7 @@ export class HistCanvas extends TraceCanvas {
   draw() {
     const traceData = this.traceData as HistData,
       binConfig = traceData.binConfig;
-    let { data, highlightIndex } = traceData,
+    let { data, sampleIndex: highlightIndex } = traceData,
       kneeIndex = traceData.currentKneeIndex;
     const { hideBurnIn, savedKneeIndex } = traceData;
     let readoutValue = NO_VALUE;
@@ -393,7 +386,7 @@ export class HistCanvas extends TraceCanvas {
     } else {
       this.drawDistributionSVG(readoutValue);
     }
-    this.drawYAxisLabels(hideBurnIn, traceData.highlightIndex);
+    this.drawYAxisLabels(hideBurnIn, traceData.sampleIndex);
     this.setReadoutLabel(isHighlight, readoutValue);
     this.setStatsReadouts();
   }
@@ -904,7 +897,7 @@ export class HistCanvas extends TraceCanvas {
     requestAnimationFrame(()=>{
       this.highlightStatSpans();
       const traceData = this.traceData as HistData;
-      let { data, highlightIndex } = traceData,
+      let { data, sampleIndex: highlightIndex } = traceData,
         kneeIndex = traceData.currentKneeIndex;
       const { hideBurnIn, savedKneeIndex } = traceData;
       if (hideBurnIn && savedKneeIndex > 0) {

--- a/src/ts/ui/runner/histcanvas.ts
+++ b/src/ts/ui/runner/histcanvas.ts
@@ -628,6 +628,19 @@ export class HistCanvas extends TraceCanvas {
     const values: number[] = [];
     const kde = (traceData as HistData).distribution.kde as KernelDensityEstimate;
     if (kde) {
+      /*
+      While testing new features, I saw delphy hang a couple times. I was able to track
+      it one time to `maxVal` being set to `Infinity`, but it made no sense how it would
+      get that value. I added this debug info, but have not been able to recreate the
+      hanging again. [mark 260407]
+      */
+      if ((!Number.isFinite(minVal) && !isNaN(minVal)) || (!Number.isFinite(maxVal) && !isNaN(maxVal))) {
+        console.warn(`bad maxVal calculation in drawDistributionSVG for ${this.className}:
+          min: ${minVal}, max: ${maxVal},
+          firstValue: ${firstValue}, lastValue: ${lastValue}, histoValueRange: ${histoValueRange},
+          histoSize: ${histoSize}, N: ${N} binSize: ${binSize}`);
+        return;
+      }
       for (let val = minVal; val <= maxVal; val+= distStep) {
         const pdf = kde.pdf(val);
         const prob = step * pdf;

--- a/src/ts/ui/runner/histdata.ts
+++ b/src/ts/ui/runner/histdata.ts
@@ -31,7 +31,6 @@ export class HistData extends TraceData {
   data:number[] = [];
   postBurnIn: number[] = [];
   mccIndex: number = UNSET;
-  highlightIndex: number = UNSET;
   mean = 0;
   ess: number = UNSET;
   act: number = UNSET;
@@ -211,7 +210,7 @@ export class HistData extends TraceData {
     super.setKneeIndex(count, kneeIndex);
     this.mccIndex = mccIndex;
     this.hideBurnIn = hideBurnIn;
-    this.highlightIndex = sampleIndex;
+    this.sampleIndex = sampleIndex;
     this.displayCount = this.hideBurnIn && this.savedKneeIndex > 0 ? this.count - this.savedKneeIndex : this.count;
   }
 

--- a/src/ts/ui/runner/runui.ts
+++ b/src/ts/ui/runner/runui.ts
@@ -921,7 +921,7 @@ export class RunUI extends UIScreen {
         if (canvas instanceof HistCanvas) {
           canvas.setData(kneeIndex, mccIndex, hideBurnIn, sampleIndex, stepsPerSample, steps);
         } else if (canvas instanceof GammaHistCanvas) {
-          canvas.setRangeData(kneeIndex, sampleIndex);
+          canvas.setRangeData(kneeIndex);
         }
       }
     });

--- a/src/ts/ui/runner/runui.ts
+++ b/src/ts/ui/runner/runui.ts
@@ -282,7 +282,7 @@ export class RunUI extends UIScreen {
     const growthRateFnc = ()=>(this.pythia as Pythia).popModelHist.map(popModel => (popModel as ExpPopModel).g / POP_GROWTH_FACTOR);
     this.traceChartConfig[TraceChart.growthRate] = { name: "Growth rate", unit: "doublings / year", className: "growth-rate", dataFnc: growthRateFnc, isDiscrete: false};
     const gammaDataFnc: GammaDataFunction = ()=>(this.pythia as Pythia).popModelHist.map(popModel => (popModel as SkygridPopModel));
-    this.traceChartConfig[TraceChart.gamma] = { name: "Effective population size in years", dataFnc: gammaDataFnc};
+    this.traceChartConfig[TraceChart.gamma] = { name: "Effective population size", dataFnc: gammaDataFnc};
 
     this.traceChartConfig[TraceChart.logPosterior] = { name: "ln(Posterior)", unit: '', className: "ln-post", dataFnc: ()=>(this.pythia as Pythia).logPosteriorHist, isDiscrete: false};
     this.traceChartConfig[TraceChart.evolutionaryTime] = { name: "Total Evolutionary Time", unit: "years", className: "tot-time", dataFnc: ()=>(this.pythia as Pythia).totalBranchLengthHist.map(t=>t/DAYS_PER_YEAR), isDiscrete: false};

--- a/src/ts/ui/runner/runui.ts
+++ b/src/ts/ui/runner/runui.ts
@@ -423,7 +423,7 @@ export class RunUI extends UIScreen {
 
     });
     this.submitAdvancedButton = this.div.querySelector(".advanced--submit-button") as HTMLButtonElement;
-    this.advancedToggle.addEventListener("change", (event)=>{
+    this.advancedToggle.addEventListener("change", ()=>{
       // event.stopPropagation();
       if (this.advancedToggle.checked) {
         this.advancedFormContainer.classList.add("active");

--- a/src/ts/ui/runner/runui.ts
+++ b/src/ts/ui/runner/runui.ts
@@ -65,7 +65,9 @@ type HistChartCustomLabelConfig = {
 
 type PopChartConfig = {
   name: string,
-  dataFnc: GammaDataFunction
+  subtitle: string,
+  dataFnc: GammaDataFunction,
+  className: string
 }
 
 enum TraceChart {
@@ -282,7 +284,7 @@ export class RunUI extends UIScreen {
     const growthRateFnc = ()=>(this.pythia as Pythia).popModelHist.map(popModel => (popModel as ExpPopModel).g / POP_GROWTH_FACTOR);
     this.traceChartConfig[TraceChart.growthRate] = { name: "Growth rate", unit: "doublings / year", className: "growth-rate", dataFnc: growthRateFnc, isDiscrete: false};
     const gammaDataFnc: GammaDataFunction = ()=>(this.pythia as Pythia).popModelHist.map(popModel => (popModel as SkygridPopModel));
-    this.traceChartConfig[TraceChart.gamma] = { name: "Effective population size", dataFnc: gammaDataFnc};
+    this.traceChartConfig[TraceChart.gamma] = { name: `Effective population size`, className: "effective-population-size", subtitle: "Showing Median and 95% HPD", dataFnc: gammaDataFnc};
 
     this.traceChartConfig[TraceChart.logPosterior] = { name: "ln(Posterior)", unit: '', className: "ln-post", dataFnc: ()=>(this.pythia as Pythia).logPosteriorHist, isDiscrete: false};
     this.traceChartConfig[TraceChart.evolutionaryTime] = { name: "Total Evolutionary Time", unit: "years", className: "tot-time", dataFnc: ()=>(this.pythia as Pythia).totalBranchLengthHist.map(t=>t/DAYS_PER_YEAR), isDiscrete: false};
@@ -590,8 +592,8 @@ export class RunUI extends UIScreen {
       });
       gammas.forEach((tc: TraceChart)=>{
         const config : PopChartConfig = this.traceChartConfig[tc] as PopChartConfig;
-        const { name, dataFnc } = config;
-        const canvas = new GammaHistCanvas(name, dataFnc);
+        const { name, dataFnc, subtitle, className } = config;
+        const canvas = new GammaHistCanvas(name, subtitle, className, dataFnc);
         this.traceCanvases.push(canvas);
         if (toShow.includes(tc)) {
           this.defaultCanvases.push(canvas);

--- a/src/ts/ui/runner/tracedata.ts
+++ b/src/ts/ui/runner/tracedata.ts
@@ -4,7 +4,6 @@ import { GammaDataFunction, HistDataFunction } from './runcommon';
 export class TraceData {
 
 
-  sampleIndex: number;
   sampleCount: number;
 
 
@@ -17,7 +16,7 @@ export class TraceData {
   unit:string;
   count: number;
 
-  highlightIndex: number;
+  sampleIndex: number;
 
   /*
   distinguish between the knee index
@@ -42,9 +41,8 @@ export class TraceData {
     this.dataMin = UNSET;
     this.dataMax = UNSET;
 
-    this.sampleIndex = UNSET;
     this.count = 0;
-    this.highlightIndex = UNSET;
+    this.sampleIndex = UNSET;
     this.savedKneeIndex = UNSET;
     this.currentKneeIndex = UNSET;
     this.settingKnee = false;
@@ -62,7 +60,7 @@ export class TraceData {
 
 
   handleTreeHighlight(treeIndex: number): void {
-    this.highlightIndex = treeIndex;
+    this.sampleIndex = treeIndex;
   }
 
 

--- a/src/views/runner.html
+++ b/src/views/runner.html
@@ -275,33 +275,37 @@
                 </div>
                 <div class="chart">
                   <div class="feature">
+                    <div class="displays">
+                      <div class="graph display">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 145 96">
+                          <path class="trend range" d=""></path>
+                          <path class="trend median" d=""></path>
+                          <path class="trend sample" d=""></path>
+                          <!-- <path class="dist"></path> -->
+                          <line class="highlight marker hpdmax" x1="0" y1="-2" x2="0" y2="-1"></line>
+                          <line class="highlight marker median" x1="0" y1="-2" x2="0" y2="-1"></line>
+                          <line class="highlight marker hpdmin" x1="0" y1="-2" x2="0" y2="-1"></line>
+                          <g class="highlight">
+                            <line class="dist" x1="0" y1="-1" x2="0" y2="-1"></line>
+                            <ellipse class="point hpdmax" cx="0" cy="-1" rx="2" ry="2"></ellipse>
+                            <ellipse class="point median" cx="0" cy="-1" rx="2" ry="2"></ellipse>
+                            <ellipse class="point hpdmin" cx="0" cy="-1" rx="2" ry="2"></ellipse>
+                          </g>
+                        </svg>
+                      </div>
+                    </div>
                     <div class="y axis">
                       <svg class="log-scale-ticks" xmlns="http://www.w3.org/2000/svg" >
                         <text x="0">##</text>
                         <line></line>
                       </svg>
                     </div>
-                    <div class="displays">
-                      <div class="graph display">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 96">
-                          <path class="trend range" d=""></path>
-                          <path class="trend median" d=""></path>
-                          <path class="trend sample" d=""></path>
-                          <!-- <path class="dist"></path> -->
-                          <g class="highlight">
-                            <line x1="0" y1="" x2="0" y2=""></line>
-                            <ellipse class="point hpdmax" cx="0" cy="" rx="2" ry="2"></ellipse>
-                            <ellipse class="point median" cx="0" cy="" rx="2" ry="2"></ellipse>
-                            <ellipse class="point hpdmin" cx="0" cy="" rx="2" ry="2"></ellipse>
-                          </g>
-                        </svg>
-                      </div>
-                    </div>
                   </div>
                   <div class="support">
                     <div class="x axis">
                       <div class="min-date"></div>
                       <div class="max-date"></div>
+                      <div class="hover-date"></div>
                     </div>
                   </div>
                 </div>

--- a/src/views/runner.html
+++ b/src/views/runner.html
@@ -281,18 +281,24 @@
                           <path class="trend range" d=""></path>
                           <path class="trend median" d=""></path>
                           <path class="trend sample" d=""></path>
-                          <!-- <path class="dist"></path> -->
-                          <line class="highlight marker hpdmax" x1="0" y1="-2" x2="0" y2="-1"></line>
-                          <line class="highlight marker median" x1="0" y1="-2" x2="0" y2="-1"></line>
-                          <line class="highlight marker hpdmin" x1="0" y1="-2" x2="0" y2="-1"></line>
+                          <rect class="scrim" x="0" y="0" width="0" height="0"></rect>
                           <g class="highlight">
                             <line class="dist" x1="0" y1="-1" x2="0" y2="-1"></line>
                             <ellipse class="point hpdmax" cx="0" cy="-1" rx="2" ry="2"></ellipse>
                             <ellipse class="point median" cx="0" cy="-1" rx="2" ry="2"></ellipse>
                             <ellipse class="point hpdmin" cx="0" cy="-1" rx="2" ry="2"></ellipse>
-                            <!-- <text class="hpdmax" x="0" y="5">95% HPD Max</text>
-                            <text class="median" x="0" y="50.5">Median</text>
-                            <text class="hpdmin" x="0" y="91">95% HPD Min</text> -->
+                            <text class="hover hpdmax" x="4">
+                              <tspan class="value"></tspan>
+                              <tspan class="label" dx="2">max</tspan>
+                            </text>
+                            <text class="hover median" x="4">
+                              <tspan class="value"></tspan>
+                              <tspan class="label" dx="2">median</tspan>
+                            </text>
+                            <text class="hover hpdmin" x="4">
+                              <tspan class="value"></tspan>
+                              <tspan class="label" dx="2">min</tspan>
+                            </text>
                           </g>
                         </svg>
                       </div>

--- a/src/views/runner.html
+++ b/src/views/runner.html
@@ -291,6 +291,11 @@
                             <ellipse class="point median" cx="0" cy="-1" rx="2" ry="2"></ellipse>
                             <ellipse class="point hpdmin" cx="0" cy="-1" rx="2" ry="2"></ellipse>
                           </g>
+                          <g class="labels">
+                            <text class="hpdmax" x="0" y="5">95% HPD Max</text>
+                            <text class="median" x="0" y="50.5">Median</text>
+                            <text class="hpdmin" x="0" y="91">95% HPD Min</text>
+                          </g>
                         </svg>
                       </div>
                     </div>

--- a/src/views/runner.html
+++ b/src/views/runner.html
@@ -271,7 +271,7 @@
               <div class="module population">
                 <div class="header">
                   <h3 class="title"></h3>
-                  <p class="readuout-unit"></p>
+                  <p class="subtitle"></p>
                 </div>
                 <div class="chart">
                   <div class="feature">
@@ -290,19 +290,21 @@
                             <ellipse class="point hpdmax" cx="0" cy="-1" rx="2" ry="2"></ellipse>
                             <ellipse class="point median" cx="0" cy="-1" rx="2" ry="2"></ellipse>
                             <ellipse class="point hpdmin" cx="0" cy="-1" rx="2" ry="2"></ellipse>
-                          </g>
-                          <g class="labels">
-                            <text class="hpdmax" x="0" y="5">95% HPD Max</text>
+                            <!-- <text class="hpdmax" x="0" y="5">95% HPD Max</text>
                             <text class="median" x="0" y="50.5">Median</text>
-                            <text class="hpdmin" x="0" y="91">95% HPD Min</text>
+                            <text class="hpdmin" x="0" y="91">95% HPD Min</text> -->
                           </g>
                         </svg>
                       </div>
                     </div>
                     <div class="y axis">
                       <svg class="log-scale-ticks" xmlns="http://www.w3.org/2000/svg" >
-                        <text x="0">##</text>
+                        <text class="tick" x="0"></text>
                         <line></line>
+                        <text class="hover">
+                          <tspan class="value"></tspan>
+                          <tspan class="label" dx="2"></tspan>
+                        </text>
                       </svg>
                     </div>
                   </div>

--- a/src/views/runner.html
+++ b/src/views/runner.html
@@ -287,11 +287,14 @@
                           <path class="trend range" d=""></path>
                           <path class="trend median" d=""></path>
                           <path class="trend sample" d=""></path>
+                          <!-- <path class="dist"></path> -->
+                          <g class="highlight">
+                            <line x1="0" y1="" x2="0" y2=""></line>
+                            <ellipse class="point hpdmax" cx="0" cy="" rx="2" ry="2"></ellipse>
+                            <ellipse class="point median" cx="0" cy="" rx="2" ry="2"></ellipse>
+                            <ellipse class="point hpdmin" cx="0" cy="" rx="2" ry="2"></ellipse>
+                          </g>
                         </svg>
-                        <div class="position">
-                          <div class="x p"></div>
-                          <div class="y p"><div class="pos"></div></div>
-                        </div>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
Add hover functionality to the gamma chart. Provide readouts for the median and 95% HPD min and max. 