### PR TITLE
preserve subtree selection across tabs

### DIFF
--- a/src/ts/sharedstate.ts
+++ b/src/ts/sharedstate.ts
@@ -1,7 +1,7 @@
 import { Pythia } from './pythia/pythia';
 import { MccConfig, ConfigExport } from './ui/mccconfig';
 import { Mutation } from './pythia/delphy_api';
-import { NavigateFunctionType } from './ui/common';
+import { NavigateFunctionType, UNSET } from './ui/common';
 import { RecordQuality } from './recordquality';
 
 
@@ -75,6 +75,7 @@ export class SharedState {
   resetSelections() : void {
     this.nodeList.length = 0;
     this.mutationsNeedReloading = this.mutationList.length > 0;
+    this.mccConfig.configuredRoot = UNSET;
   }
 
   markMutationsUpdated() : void {

--- a/src/ts/ui/lineages/lineagestreecanvas.ts
+++ b/src/ts/ui/lineages/lineagestreecanvas.ts
@@ -19,7 +19,6 @@ export class LineagesTreeCanvas extends MccTreeCanvas {
   highlightedDate: number = UNSET;
   highlightCanvas: HTMLCanvasElement;
   highlightCtx: CanvasRenderingContext2D;
-  configuredRootNode: number = UNSET;
 
 
   constructor(canvas: HTMLCanvasElement | PdfCanvas,
@@ -81,17 +80,18 @@ export class LineagesTreeCanvas extends MccTreeCanvas {
         selectionCallback(nodeIndex);
       }
     });
-
-
   }
 
 
   setNodes(nodes: DisplayNode [], descendants: NodePair[], configuredRootNode: number) {
     this.nodes = nodes;
     this.descendants = descendants;
-    if (this.configuredRootNode !== configuredRootNode) {
-      this.configuredRootNode = configuredRootNode;
+    if (this.rootIndex !== configuredRootNode) {
+      this.rootIndex = configuredRootNode;
       this.setRootNode(configuredRootNode);
+      if (this.mccConfig) {
+        this.mccConfig.configuredRoot = configuredRootNode;
+      }
       // const [ minDate, maxDate ] = this.getDateRange();
       // const timlineIndices = getTimelineIndices(minDate, maxDate);
       this.draw();

--- a/src/ts/ui/mccconfig.ts
+++ b/src/ts/ui/mccconfig.ts
@@ -36,6 +36,7 @@ export class MccConfig {
   colorChooser: ColorChooser;
 
   metadataColorsDirty: boolean;
+  configuredRoot: number = UNSET;
 
 
 
@@ -248,7 +249,7 @@ export class MccConfig {
 
   unbind() : void {
     if (this.div) {
-      console.trace('running unbind');
+      // console.trace('running unbind');
       const div: HTMLDivElement = this.div;
       const removeChangeListener = (selector: string, callback:ChangeHandler)=>{
         const ele = div.querySelector(selector) as HTMLInputElement;

--- a/src/ts/ui/mcctreecanvas.ts
+++ b/src/ts/ui/mcctreecanvas.ts
@@ -216,8 +216,10 @@ export class MccTreeCanvas {
 
 
   setConfig(mccConfig : MccConfig) : void {
+    // console.log(`setting MccConfig root ${mccConfig.configuredRoot}`);
     this.mccConfig = mccConfig;
     this.confidenceThreshold = mccConfig.confidenceThreshold;
+    this.rootIndex = mccConfig.configuredRoot;
     this.colorsUnSet = true;
   }
 
@@ -225,7 +227,7 @@ export class MccTreeCanvas {
     this.colorsUnSet = true;
     const nodeCount = tree.getSize();
     if (nodeCount > 0) {
-      if (this.rootIndex === UNSET || this.tree !== tree) {
+      if (this.rootIndex === UNSET) {
         this.rootIndex = (tree as Tree).getRootIndex();
       }
       this.gatherNodeStats(tree, creds);

--- a/src/ts/ui/runner/runui.ts
+++ b/src/ts/ui/runner/runui.ts
@@ -198,6 +198,7 @@ export class RunUI extends MccUI {
             this.pythia.setKneeIndexByPct(pct);
             this.pythia.recalcMccTree().then(()=>{
               if (currentKnee !== this.pythia?.kneeIndex) {
+                this.sharedState.resetSelections();
                 this.updateRunData();
               }
             });
@@ -707,6 +708,7 @@ export class RunUI extends MccUI {
       last = stepsHist.length - 1;
     if (this.stepCount === stepsHist[last]) return;
     this.updateRunData();
+    this.sharedState.resetSelections();
     if (!this.is_running && this.timerHandle !== 0) {
       clearTimeout(this.timerHandle);
       this.timerHandle = 0;
@@ -717,9 +719,8 @@ export class RunUI extends MccUI {
   }
 
 
-
-
   updateRunData():void {
+    // console.log(`updateRunData root ${this.sharedState.mccConfig.configuredRoot}`);
     if (!this.pythia) return;
     const stepsHist = this.pythia.stepsHist,
       last = stepsHist.length - 1;
@@ -732,10 +733,8 @@ export class RunUI extends MccUI {
       this.mccIndex = this.pythia.getMccIndex();
       const mccTree = mccRef.getMcc(),
         nodeConfidence = mccRef.getNodeConfidence();
-      if (mccTree !== this.mccTreeCanvas.tree) {
-        this.mccTreeCanvas.setTreeNodes(mccTree, nodeConfidence);
-        this.sharedState.resetSelections();
-      }
+      this.mccTreeCanvas.rootIndex = UNSET;
+      this.mccTreeCanvas.setTreeNodes(mccTree, nodeConfidence);
       const earliestMCCDate = mccRef.getMcc().getTimeOf(mccTree.getRootIndex())
       this.mccMinDate.setTarget(earliestMCCDate);
       if (oldRef) {
@@ -848,6 +847,7 @@ export class RunUI extends MccUI {
   start():void {
     if (this.timerHandle === 0) {
       this.updateRunData();
+      this.sharedState.resetSelections();
       this.timerHandle = setInterval(()=>this.pingPythiaForUpdate(), 30) as unknown as number;
     }
     if (this.pythia) {
@@ -998,6 +998,7 @@ export class RunUI extends MccUI {
       this.stepCount = 0;
       this.updateParamsUI();
       this.updateRunData();
+      this.sharedState.resetSelections();
       this.disableAnimation = false;
       setStage(STAGES.loaded);
     });


### PR DESCRIPTION
If an inner node is set as the root node on the lineages page, other pages should display the tree the same way. 

Except for the run / trees page. Since inner node ids change from sample to sample, we'd be jumping between random nodes if we just use the id. It might be possible to find the best approximation of the corresponding branch by looking at the tips, but even so, the mcmc moves are not constrained to branches that are currently visible: the modeling continues on the entire tree, not just the selected subtree. So showing the subtree would be misleading about the kinds of analysis being done. 