### PR TITLE
make the prevalence selector and the metadata selects "and" gates, not "or" gates

### DIFF
--- a/src/ts/ui/lineages/corelineagesdata.ts
+++ b/src/ts/ui/lineages/corelineagesdata.ts
@@ -4,7 +4,7 @@ import { MutationDistribution } from "../../pythia/mutationdistribution";
 import { Pythia } from "../../pythia/pythia";
 import { SharedState } from "../../sharedstate";
 import { assembleInheritanceTree, getTipCounts, InheritanceNode, isTip } from "../../util/treeutils";
-import { ColorDict, ColorOption, numericSortReverse, UNDEF, UNSET } from "../common";
+import { numericSortReverse, UNDEF, UNSET } from "../common";
 import { DisplayNode, NULL_NODE_CODE } from "./displaynode";
 import { Distribution } from "../distribution";
 import { MccTreeCanvas } from "../mcctreecanvas";
@@ -18,7 +18,7 @@ import { MccConfig } from "../mccconfig";
 
 const DEFAULT_HI_CONFIDENCE = 0.9;
 const DEFAULT_PEAK_PREVALENCE = 0.05;
-const SELECTED_BY_PREVALENCE = 'prevalence';
+const AUTO_SELECTED = 'poweredbydelphy';
 const SELECTED_BY_USER = 'curated';
 
 const SCHEMATIC_MIN_SIZE = 12;
@@ -61,11 +61,6 @@ export type ChartData = {
 
 export type updateFunction = (_: ChartData)=>void;
 
-interface ParentMetadataType  {
-  node: number,
-  parentValue: string
-}
-
 
 const defaultChartData : ChartData = {
   nodeDistributions: [],
@@ -106,6 +101,7 @@ export class CoreLineagesData {
   private nodeConfidence: number[] = [];
   private tipCounts: number[] = [];
   private peakPrevalence: number[] = [];
+  private metadataTransitionNodes: { [_: string] : number[]} = {};
   private getY: getYFunction | null = null;
 
 
@@ -118,6 +114,8 @@ export class CoreLineagesData {
   private selectionReasons: Set<string>[] = [];
   private peakPrevalenceThreshold: number = DEFAULT_PEAK_PREVALENCE;
   private confidenceThreshold: number = DEFAULT_HI_CONFIDENCE;
+  private filteringByPeakPrevalence = true;
+  private filteringByMetadataFields: Set<string> = new Set();
 
   /*
   bypassed nodes happen when the user selects an inner
@@ -196,8 +194,11 @@ export class CoreLineagesData {
         this.getNodeDisplay(rootIndex, true, true, this.rootNode);
       }
       this.peakPrevalence.length = 0;
+      this.metadataTransitionNodes = {};
       this.setNodePeakPrevalence(this.confidenceThreshold);
-      this.autoSelectPeakPrevalence();
+      if (this.filteringByPeakPrevalence) {
+        this.autoSelectPeakPrevalence();
+      }
       this.selectNodesByImpact();
       this.selectionTreeData.setData(this.selectedNodes);
       this.setChartData();
@@ -389,20 +390,10 @@ export class CoreLineagesData {
         this.peakPrevalenceThreshold = 1;
       }
     }
-
   }
 
   selectNodesByImpact() : void {
-    const peakThreshold = this.peakPrevalenceThreshold;
-    const confidenceThreshold = this.confidenceThreshold
-    const pythia = this.pythia;
-    let autoSelected: number[] = [];
-    if (pythia) {
-      // const startTime = Date.now();
-      autoSelected = this.getHighImpactConfidentNodes(peakThreshold, confidenceThreshold);
-      // console.log(`elapsed: ${(Date.now() - startTime) / 1000} s for ${influentialNodes.length} nodes`, this.peakPrevalence);
-    }
-    this.setAutoNodeSelections(autoSelected, SELECTED_BY_PREVALENCE);
+    this.setAutoNodeSelections();
   }
 
 
@@ -449,19 +440,64 @@ export class CoreLineagesData {
 
 
 
-  private setAutoNodeSelections(autoSelected: number[], selectionSource: string) : void {
+  private setAutoNodeSelections() : void {
     // console.log(`adding automatic selections based on '${selectionSource}'`, autoSelected);
     const already: boolean[] = [];
     this.selectedNodes.map(node=>already[node.index] = true);
     /* clear previous selections, in case we are altering the criteria here (like node confidence, etc. ) */
     this.selectionReasons.forEach((reasons:Set<string>)=>{
-      reasons.delete(selectionSource);
+      reasons.delete(AUTO_SELECTED);
     });
+    let autoSelected: number[] = [];
+    if (this.filteringByMetadataFields.size > 0) {
+      const nodes: boolean[] = [];
+      const lookup: boolean[] = [];
+      Object.values(this.metadataTransitionNodes).forEach((nodeIndices, i)=>{
+        if (i === 0) {
+          /*
+          build a lookup by node index of whether it passes the
+          test of the first metadata field
+          */
+          nodeIndices.forEach(nodeIndex=>nodes[nodeIndex] = true);
+        } else {
+          /*
+          for each node, does it also pass the test of the current metadata field?
+          */
+          lookup.length = 0;
+          nodeIndices.forEach(nodeIndex=>lookup[nodeIndex] = true);
+          nodes.forEach((_, i)=>{
+            if (lookup[i] === undefined){
+              nodes[i] = false;
+            }
+          });
+        }
+      });
+      nodes.forEach((passes, index)=>{
+        if (passes) {
+          autoSelected.push(index);
+        }
+      });
+      if (this.filteringByPeakPrevalence) {
+        const peakThreshold = this.peakPrevalenceThreshold;
+        const confidenceThreshold = this.confidenceThreshold;
+        const {peakPrevalence, nodeConfidence} = this;
+        autoSelected = autoSelected.filter(nodeIndex=>{
+          const pp = peakPrevalence[nodeIndex];
+          const nc = nodeConfidence[nodeIndex];
+          return pp >= peakThreshold
+            && nc >= confidenceThreshold;
+        });
+      }
+    } else if (this.filteringByPeakPrevalence) {
+      const peakThreshold = this.peakPrevalenceThreshold;
+      const confidenceThreshold = this.confidenceThreshold
+      autoSelected = this.getHighImpactConfidentNodes(peakThreshold, confidenceThreshold);
+    }
     autoSelected.forEach(nodeIndex=>{
       if (this.selectionReasons[nodeIndex] === undefined) {
         this.selectionReasons[nodeIndex] = new Set();
       }
-      this.selectionReasons[nodeIndex].add(selectionSource);
+      this.selectionReasons[nodeIndex].add(AUTO_SELECTED);
     });
     /* what nodes have reason to show up? */
     const shouldShow: number[] = [];
@@ -495,10 +531,11 @@ export class CoreLineagesData {
   */
   updatePeakPrevalenceThreshold(yes: boolean, minPeak: number) : void {
     this.peakPrevalenceThreshold = minPeak / 100;
+    this.filteringByPeakPrevalence = yes;
     if (yes) {
       this.selectNodesByImpact();
     } else {
-      this.setAutoNodeSelections([], SELECTED_BY_PREVALENCE);
+      this.setAutoNodeSelections();
       if (this.selectedNodes.length === 0) {
         this.selectedNodes.push(this.rootNode);
       }
@@ -523,9 +560,12 @@ export class CoreLineagesData {
     const mccConfig: MccConfig = this.sharedState.mccConfig;
     if (!mccConfig || !mccConfig.metadata) return
     if (yes) {
-      if (pythia && mccConfig.metadata.getFields().includes(field)) {
-        const introductions = this.getMetadataTransitionNodes(mccConfig, field);
-        this.setAutoNodeSelections(introductions, `metadata:${field}`);
+      this.filteringByMetadataFields.add(field);
+      if (this.metadataTransitionNodes[field] === undefined) {
+        if (pythia && mccConfig.metadata.getFields().includes(field)) {
+          const introductions = this.getMetadataTransitionNodes(mccConfig, field);
+          this.metadataTransitionNodes[field] = introductions;
+        }
       } else {
         console.debug(`somehow, we requested finding nodes by metadata transition…
           …but there's no metadata available.  
@@ -533,8 +573,9 @@ export class CoreLineagesData {
       }
     } else {
       /* find the nodes that were added by the transition, and clear them */
-      this.setAutoNodeSelections([], `metadata:${field}`);
+      this.filteringByMetadataFields.delete(field);
     }
+    this.setAutoNodeSelections();
     if (this.selectionTreeData) {
       if (this.selectedNodes.length === 0) {
         this.selectedNodes.push(this.rootNode);

--- a/src/ts/ui/lineages/corelineagesdata.ts
+++ b/src/ts/ui/lineages/corelineagesdata.ts
@@ -185,7 +185,8 @@ export class CoreLineagesData {
       this.nodeConfidence = mccTreeCanvas.creds;
       this.tipCounts = getTipCounts(summaryTree);
       this.getY = (n:number)=>mccTreeCanvas.getRawY(n);
-      this.nodeMetadata = this.sharedState.mccConfig.nodeMetadata;
+      const mccConfig = this.sharedState.mccConfig;
+      this.nodeMetadata = mccConfig.nodeMetadata;
       this.tipIds = this.sharedState.getTipIds();
       this.isApobecEnabled = isApobecEnabled;
       const mrcaMaker : MRCANodeCreator = (nodeIndex: number)=>this.getNodeDisplay(nodeIndex, true, false);
@@ -194,11 +195,15 @@ export class CoreLineagesData {
         this.getNodeDisplay(rootIndex, true, true, this.rootNode);
       }
       this.peakPrevalence.length = 0;
-      this.metadataTransitionNodes = {};
       this.setNodePeakPrevalence(this.confidenceThreshold);
       if (this.filteringByPeakPrevalence) {
         this.autoSelectPeakPrevalence();
       }
+      this.metadataTransitionNodes = {};
+      this.filteringByMetadataFields.forEach(field=>{
+        const introductions = this.getMetadataTransitionNodes(mccConfig, field);
+        this.metadataTransitionNodes[field] = introductions;
+      });
       this.selectNodesByImpact();
       this.selectionTreeData.setData(this.selectedNodes);
       this.setChartData();
@@ -536,11 +541,11 @@ export class CoreLineagesData {
       this.selectNodesByImpact();
     } else {
       this.setAutoNodeSelections();
+    }
+    if (this.selectionTreeData) {
       if (this.selectedNodes.length === 0) {
         this.selectedNodes.push(this.rootNode);
       }
-    }
-    if (this.selectionTreeData) {
       this.selectionTreeData.setData(this.selectedNodes);
       this.setChartData();
     }

--- a/src/ts/ui/lineages/lineagesui.ts
+++ b/src/ts/ui/lineages/lineagesui.ts
@@ -202,7 +202,7 @@ export class LineagesUI extends MccUI {
     this.nodeListDisplay.setNodes(nodes);
     (this.mccTreeCanvas as LineagesTreeCanvas).setNodes(actualNodes, nodePairs, selectedRootIndex);
     this.nodeSchematic.setPrevalenceSelectors(true, peakPrevalence);
-    this.nodeSchematic.setData(nodePairs, rootNode);
+    this.nodeSchematic.setData(nodePairs, rootNode, nodes.length);
     this.nodeSchematic.highlightNode(highlightNode);
     this.nodeListDisplay.highlightNode(highlightNode);
     if (highlightNode === null || highlightNode.index === UNSET) {

--- a/src/ts/ui/lineages/nodeschematic.ts
+++ b/src/ts/ui/lineages/nodeschematic.ts
@@ -393,7 +393,7 @@ export class NodeSchematic {
       // index the mutations by the descendent
       this.pairsByDescendant[pair.descendant.index] = pair;
     });
-    COUNT_SPAN.textContent = `${nfc(nodeCount)} nodes${ nodeCount === 1 ? '' : 's'}` ;
+    COUNT_SPAN.textContent = `${nfc(nodeCount)} node${ nodeCount === 1 ? '' : 's'}` ;
     // this.setLayout();
   }
 

--- a/src/ts/ui/lineages/nodeschematic.ts
+++ b/src/ts/ui/lineages/nodeschematic.ts
@@ -1,10 +1,11 @@
-import { PREVALENCE_CALLBACK_TYPE, UNSET } from "../common";
+import { nfc, PREVALENCE_CALLBACK_TYPE, UNSET } from "../common";
 import { DisplayNode } from "./displaynode";
 import { DismissNodeCallback, HoverCallback, MetadataToggleCallback, NodePair, NodeRelationType } from "./lineagescommon";
 import { TreeNode } from "./selectiontreedata";
 
 
 const CONTROLS = document.querySelector("#lineages #lineages--schematic-controls") as HTMLDivElement;
+const COUNT_SPAN = document.querySelector("#lineages--schematic-count") as HTMLSpanElement;
 const PREVALENCE_THRESHOLD_TOGGLE = CONTROLS.querySelector("#lineages--peak-prevalence-toggle input") as HTMLInputElement;
 const PREVALENCE_THRESHOLD_SLIDER = CONTROLS.querySelector("#lineages--peak-prevalence-selector") as HTMLInputElement;
 const PREVALENCE_THRESHOLD_READOUT = CONTROLS.querySelector("#lineages--peak-prevalence--readout") as HTMLSpanElement
@@ -383,7 +384,7 @@ export class NodeSchematic {
   @param rootNode: the root node of the tree we will display.
     We can traverse the entire tree by traversing the children of each node.
   */
-  setData(pairs: NodePair[], rootNode: TreeNode | null) {
+  setData(pairs: NodePair[], rootNode: TreeNode | null, nodeCount: number) {
     // console.debug(src.map(ncd=>`${NodePairType[ncd.nodePair.pairType]} ${ncd.nodePair.mutations.length} mutations, nodeAIsUpper ? ${nodeAIsUpper}`));
     this.rootNode = rootNode;
     this.pairsByDescendant = [];
@@ -392,6 +393,7 @@ export class NodeSchematic {
       // index the mutations by the descendent
       this.pairsByDescendant[pair.descendant.index] = pair;
     });
+    COUNT_SPAN.textContent = `${nfc(nodeCount)} nodes${ nodeCount === 1 ? '' : 's'}` ;
     // this.setLayout();
   }
 

--- a/src/ts/ui/lineages/nodeschematic.ts
+++ b/src/ts/ui/lineages/nodeschematic.ts
@@ -156,8 +156,8 @@ class TreeNodeDisplay {
     // const mutTextNode = this.mutLabel.querySelector("text") as SVGTextElement;
     // const mutRect = this.mutLabel.querySelector("rect") as SVGRectElement;
 
-    // const label = mrca ? "" : node.label;
-    const label = `${node.index}`;
+    const label = mrca ? "" : node.label;
+    // const label = `${node.index}`;
     textNode.textContent = label;
     if (color === '') {
       rect.setAttribute("fill", '');

--- a/src/ts/ui/nodemetadata.ts
+++ b/src/ts/ui/nodemetadata.ts
@@ -258,8 +258,8 @@ export class NodeMetadata {
         if (nodeFieldOptions.length === 1) {
           value = nodeFieldOptions[0];
         } else {
-          // value = getRandom(nodeFieldOptions);
-          value = getWeightedRandom(nodeFieldOptions, tipTallies[index][column]);
+          value = getRandom(nodeFieldOptions);
+          // value = getWeightedRandom(nodeFieldOptions, tipTallies[index][column]);
         }
         nodeValues[index][c].value = value;
         nodeValues[index][c].counts = tipTallies[index][column];

--- a/src/views/lineages.html
+++ b/src/views/lineages.html
@@ -79,7 +79,7 @@
 
             <div class="header">
               <div class="title">
-                <h4>Node diagram</h4>
+                <h4>Node diagram <span id="lineages--schematic-count"></span></h4>
               </div>
             </div>
             <div id="lineages--schematic-controls">

--- a/src/views/lineages.html
+++ b/src/views/lineages.html
@@ -79,7 +79,8 @@
 
             <div class="header">
               <div class="title">
-                <h4>Node diagram <span id="lineages--schematic-count"></span></h4>
+                <h4>Node selection <span id="lineages--schematic-count"></span></h4>
+                <p>Select nodes for further analysis by clicking in the tree</p>
               </div>
             </div>
             <div id="lineages--schematic-controls">


### PR DESCRIPTION
Before this change, users could automatically select nodes based on whether nodes had a peak prevalence above a threshold, or whether they were the spot at which a transition happened in the metadata. Each of these possibilities could lead to too many nodes being selected. With this update, nodes selected via metadata transitions are subjected to the same prevalence criteria. This yields a much more usable number of nodes. 