### PR TITLE
Bug fix for loading dphy files

### DIFF
--- a/src/ts/pythia/pythia.ts
+++ b/src/ts/pythia/pythia.ts
@@ -1403,6 +1403,10 @@ export class Pythia {
     const firstTree = this.delphy.createPhyloTreeFromFlatbuffers(tBuff, treeInfo);
 
     this.run = await this.instantiateRun(firstTree, runParams);
+    // reset the first params
+    this.resetHist();
+    this.run.setParamsFromFlatbuffer(pBuff);
+    this.sampleCurrentTree();
 
     for (let i = 1; i < treeCount; i++) {
       progressCallback(i, treeCount);
@@ -1413,7 +1417,6 @@ export class Pythia {
       tree.delete();
 
       this.run.setParamsFromFlatbuffer(pBuff);
-
       this.sampleCurrentTree();
 
       await yieldToMain();


### PR DESCRIPTION
When loading a saved delphy run, the newly instantiated run did not overwrite the initial random parameters with the first saved tree.