### PR TITLE
bug fix: allow for distributions to have increments greater than 1

### DIFF
--- a/src/ts/ui/distribution.ts
+++ b/src/ts/ui/distribution.ts
@@ -1,5 +1,5 @@
 import {KernelDensityEstimate} from "../pythia/kde";
-import { numericSort } from "./common";
+import { nicenum, numericSort } from "./common";
 import { calcEffectiveSampleSize } from "./runner/effectivesamplesize";
 
 
@@ -86,7 +86,7 @@ export class Distribution {
           increment = this.bandwidth / 3;
         if (increment > 1) {
           medianDate = Math.floor(medianDate);
-          increment = 1;
+          increment = nicenum(increment, true);
         }
         for (let d = medianDate; d < this.max; d += increment) {
           const sample = this.getCumulativeProbability(d),


### PR DESCRIPTION
addresses #82 

One performance bottleneck that affects trees with long branches is that a mutation on a long branch can have a time distribution that is very long. Until now, the typical sampling frequency is less than one day, and if it got higher, we would set the frequency to 1 as a nice round integer. With the longer distributions, setting the frequency to 1 could result in thousands of samples being taken. This patch fixes this issue, by setting the sampling frequency via `nicenum`.