### PR TITLE
Fix histo distribution curve display

### DIFF
--- a/src/ts/ui/runner/histcanvas.ts
+++ b/src/ts/ui/runner/histcanvas.ts
@@ -625,7 +625,8 @@ export class HistCanvas extends TraceCanvas {
     */
     const minVal = edges[0];
     const maxVal = edges[edges.length-1] + binSize;
-    const distStep = (maxVal - minVal) / this.width * 3;
+    // const distStep = (maxVal - minVal) / this.width * 3;
+    const distStep = (displayMax - displayMin) / this.width;
     const probs: number[] = [];
     const values: number[] = [];
     const kde = (traceData as HistData).distribution.kde as KernelDensityEstimate;
@@ -643,7 +644,7 @@ export class HistCanvas extends TraceCanvas {
           histoSize: ${histoSize}, N: ${N} binSize: ${binSize}`);
         return;
       }
-      for (let val = minVal; val <= maxVal; val+= distStep) {
+      for (let val = displayMin; val <= displayMax; val+= distStep) {
         const pdf = kde.pdf(val);
         const prob = step * pdf;
         probs.push(prob);

--- a/src/ts/ui/runner/histcanvas.ts
+++ b/src/ts/ui/runner/histcanvas.ts
@@ -716,10 +716,11 @@ export class HistCanvas extends TraceCanvas {
           const match = highlightD.match(/^M([-\d.]+)\s+([-\d.]+)/);
           if (match) {
             const firstX = Number(match[1]);
+            const firstY = Number(match[2]);
 
             highlightD =
               `M${firstX} ${histoHeight} ` + // start at bottom baseline
-              `L${firstX} ${match[2]} ${// up to first curve point
+              `L${firstX} ${firstY} ${// up to first curve point
                 highlightD.slice(match[0].length)
               } L${x} ${y}` +
               ` L${x} ${histoHeight}` +

--- a/src/ts/ui/runner/histcanvas.ts
+++ b/src/ts/ui/runner/histcanvas.ts
@@ -625,7 +625,7 @@ export class HistCanvas extends TraceCanvas {
     */
     const minVal = edges[0];
     const maxVal = edges[edges.length-1] + binSize;
-    // const distStep = (maxVal - minVal) / this.width * 3;
+    // const distStep = (maxVal - minVal) / this.width;
     const distStep = (displayMax - displayMin) / this.width;
     const probs: number[] = [];
     const values: number[] = [];
@@ -711,21 +711,24 @@ export class HistCanvas extends TraceCanvas {
         const ht = Math.max(0, prob / maxProb * histoHeight) || 0;
         const y = histoHeight - ht;
         const x = (highlightValue - displayMin) / valRange * histoWidth;
-        if (highlightD.toLowerCase().startsWith("m")) {
-          // highlightD += `${x} ${y} ${x} ${histoHeight}`;
-          const match = highlightD.match(/^M([-\d.]+)\s+([-\d.]+)/);
-          if (match) {
-            const firstX = Number(match[1]);
-            const firstY = Number(match[2]);
-
-            highlightD =
-              `M${firstX} ${histoHeight} ` + // start at bottom baseline
-              `L${firstX} ${firstY} ${// up to first curve point
-                highlightD.slice(match[0].length)
-              } L${x} ${y}` +
-              ` L${x} ${histoHeight}` +
-              ` Z`;
-          }
+        const match = highlightD.match(/^M([-\d.]+)\s/);
+        if (match) {
+          /*
+          The fill area differs from the probability curve in that
+          in needs to start from the bottom of the chart. In most cases,
+          the probability curve starts from the bottom, but we sometimes
+          see it starting higher. It probably shouldn't, but until we
+          fix that, we can at least fix the display.
+          Parse the path of the highlight area to get the first
+          coordinate pair, and then add a coordinate pair at the same
+          x position, but at the bottom of the chart.
+          */
+          const firstX = match[1];
+          highlightD =
+            `M${firstX} ${histoHeight} L${
+              /* remove the 'M' that was there before */
+              highlightD.slice(1)
+            } ${x} ${y} ${x} ${histoHeight}`;
         } else {
           highlightD = `M${x} ${y} L${x} ${histoHeight}`;
         }

--- a/src/ts/ui/runner/histcanvas.ts
+++ b/src/ts/ui/runner/histcanvas.ts
@@ -712,7 +712,19 @@ export class HistCanvas extends TraceCanvas {
         const y = histoHeight - ht;
         const x = (highlightValue - displayMin) / valRange * histoWidth;
         if (highlightD.toLowerCase().startsWith("m")) {
-          highlightD += `${x} ${y} ${x} ${histoHeight}`;
+          // highlightD += `${x} ${y} ${x} ${histoHeight}`;
+          const match = highlightD.match(/^M([-\d.]+)\s+([-\d.]+)/);
+          if (match) {
+            const firstX = Number(match[1]);
+
+            highlightD =
+              `M${firstX} ${histoHeight} ` + // start at bottom baseline
+              `L${firstX} ${match[2]} ${// up to first curve point
+                highlightD.slice(match[0].length)
+              } L${x} ${y}` +
+              ` L${x} ${histoHeight}` +
+              ` Z`;
+          }
         } else {
           highlightD = `M${x} ${y} L${x} ${histoHeight}`;
         }


### PR DESCRIPTION
Fixes from @mark-fathom and me for #92

- Histo display now should have the same resolution as histo hover
- Histo hover highlight area should always start from bottom left corner, instead of the start of the curve which sometimes might not be 0. 