### PR TITLE
remove second 'modeled from #/# trees' label (that was never getting filled

### DIFF
--- a/src/views/runner.html
+++ b/src/views/runner.html
@@ -114,12 +114,6 @@
                 of base trees
               </output>
 
-              <output class="model--trees--label">
-                Modeling from 
-                <span id="sample-tree-count">0</span> / <span id="total-tree-count">0</span>
-                sampled tree<span class="plural">s</span>
-              </ouput>
-
               <div class="mcc-opt--confidence-range block-slider">
                 <input type="range" min="1" max="100" value="90" step="1" class="slider--input" id="mcc-opt--confidence-range" />
                 <div class="slider--track"></div>


### PR DESCRIPTION
That was at least a day's worth of work ;)

There was a duplicate label on the run tab. The code was accurately updating the first one (found above the MCC), so I removed the second

fixes issue #110 