### PR TITLE
Fix DOM structure for the MCC controls, so that we can have multiple instances

### DIFF
--- a/src/style/mccoptlist.less
+++ b/src/style/mccoptlist.less
@@ -71,7 +71,7 @@
     }
   }
 
-  input:checked + label {
+  label:has(input:checked) {
     background-color: #efefef;
     color: #444;
     font-weight: 700;
@@ -90,7 +90,7 @@
   background: transparent;
   margin: 0;
   width: 100%;
-  
+
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
   }

--- a/src/views/mcc_opts.html
+++ b/src/views/mcc_opts.html
@@ -13,37 +13,45 @@
           <div class="mcc-opt-list y-spacing">
             <p>Vertical spacing</p>
             <div class="toggle-container">
-              <input type="radio" name="mcc-opt--y-spacing" value="even" class="mcc-opt" id="y-spacing--even" />
-              <label for="y-spacing--even">Even</label>
-              <input type="radio" name="mcc-opt--y-spacing" value="genetic" class="mcc-opt" id="y-spacing--genetic" />
-              <label for="y-spacing--genetic">SNP distance</label>
+              <label>Even
+                <input type="radio" name="mcc-opt--y-spacing" value="even" class="mcc-opt" />
+              </label>
+              <label>SNP distance
+                <input type="radio" name="mcc-opt--y-spacing" value="genetic" class="mcc-opt" />
+              </label>
             </div>
           </div>
           <div class="mcc-opt-list topology">
             <p>Tree topology</p>
             <div class="toggle-container">
-              <input type="radio" name="mcc-opt--topology" value="mcc" class="mcc-opt" id="topology--mcc" />
-              <label for="topology--mcc">MCC</label>
-              <input type="radio" name="mcc-opt--topology" value="mcs" class="mcc-opt" id="topology--mcs" />
-              <label for="topology--mcs">HFS</label>
+              <label>MCC
+                <input type="radio" name="mcc-opt--topology" value="mcc" class="mcc-opt" />
+              </label>
+              <label>HFS
+                <input type="radio" name="mcc-opt--topology" value="mcs" class="mcc-opt" />
+              </label>
             </div>
           </div>
           <div class="mcc-opt-list color">
             <p>Branch coloring</p>
             <div class="toggle-container">
-              <input type="radio" name="mcc-opt--color" value="confidence" class="mcc-opt" id="color--confidence" />
-              <label for="color--confidence">Credibility</label>
-              <input type="radio" name="mcc-opt--color" value="metadata" class="mcc-opt" id="color--metadata" />
-              <label for="color--metadata">Metadata</label>
+              <label>Credibility
+                <input type="radio" name="mcc-opt--color" value="confidence" class="mcc-opt" />
+              </label>
+              <label>Metadata
+                <input type="radio" name="mcc-opt--color" value="metadata" class="mcc-opt" />
+              </label>
             </div>
           </div>
           <div class="mcc-opt-list nodes">
             <p>Inner nodes</p>
             <div class="toggle-container">
-              <input type="radio" name="mcc-opt--nodes" value="all" class="mcc-opt" id="nodes--all" />
-              <label for="nodes--all">All</label>
-              <input type="radio" name="mcc-opt--nodes" value="mutations" class="mcc-opt" id="nodes--mutations" />
-              <label for="nodes--mutations">With mutations</label>
+              <label>All
+                <input type="radio" name="mcc-opt--nodes" value="all" class="mcc-opt" />
+              </label>
+              <label>With mutations
+                <input type="radio" name="mcc-opt--nodes" value="mutations" class="mcc-opt" />
+              </label>
             </div>
           </div>
         </div>


### PR DESCRIPTION
In the old DOM structure for the MCC controls, we had the typical relationship between inputs and labels, where the label refers to the input by its `id`
```
<input type="radio" name="some-name" value="whatever" id="some-id" />
<label for="some-id">All</label>
```

But we create multiple instances of this. Subsequent labels would refer to the first instance of the input, and would never get updated. By embedding the input inside the label like this
```
<label>All
<input type="radio" name="some-name" value="whatever"/>
</label>
```
(and updating the corresponding CSS rules), we can have multiple instances and they behave just fine. 


fixes #109 