### PR TITLE
mutations page: don't fill the mutations of interest by default

### DIFF
--- a/src/ts/pythia/mutationsofinterest.ts
+++ b/src/ts/pythia/mutationsofinterest.ts
@@ -7,7 +7,8 @@ export const enum FeatureOfInterest {
   Reversals = "reversals",
   SameSite = "same_site",
   MultipleIntroductions = "multiple_introductions",
-  ManyTips = "many_tips"
+  ManyTips = "many_tips",
+  None = "none"
 }
 
 export type TreeInterestData = {treeIndex: number, intros: Introduction[]};

--- a/src/ts/ui/mutations/mutationsui.ts
+++ b/src/ts/ui/mutations/mutationsui.ts
@@ -82,7 +82,7 @@ export class MutationsUI extends MccUI {
     this.maxDate = 0;
     this.selectedMutations = [];
     this.prevalence = new MutationPrevalenceCanvas();
-    this.interestCat = FeatureOfInterest.ManyTips;
+    this.interestCat = FeatureOfInterest.None;
     this.autofill = true;
     this.mutationsOfInterest = {
       [FeatureOfInterest.Reversals]: [],
@@ -108,6 +108,7 @@ export class MutationsUI extends MccUI {
     mutationsFilter.addEventListener("input", () => {
       const value = mutationsFilter.interest.value as FeatureOfInterest;
       this.interestCat = value;
+      this.autofill = false;
 
       const descriptions = this.div.querySelectorAll(".filter-description") as NodeListOf<HTMLElement>;
       descriptions.forEach(el => {
@@ -278,7 +279,6 @@ export class MutationsUI extends MccUI {
           if (this.autofill) {
             this.clearRows();
             if (this.sharedState.mutationList.length > 0) {
-              this.autofill = false;
               const mutation = this.sharedState.mutationList[0];
               this.lookupMutation(mutation);
             }
@@ -289,14 +289,14 @@ export class MutationsUI extends MccUI {
             mutationsFilter.querySelectorAll("input").forEach(radio => {
               radio.checked = false;
             });
+            this.div.querySelectorAll(".filter-description").forEach(ele=>ele.classList.add("hidden"));
           } else {
             mutationsFilter.querySelectorAll("input").forEach(radio => {
               const value = radio.value as FeatureOfInterest;
               radio.checked = value === this.interestCat;
             });
           }
-          this.setInterest(this.autofill);
-          this.autofill = false;
+          this.setInterest();
 
           this.sharedState.mutationList.forEach(mutation=>this.lookupMutation(mutation));
 
@@ -347,10 +347,16 @@ export class MutationsUI extends MccUI {
   }
 
 
-  setInterest(autofill=false):void {
+  setInterest():void {
+    const autofill = this.autofill;
     this.clearMoiList();
-    const muts = this.mutationsOfInterest[this.interestCat],
-      minTipCount = Math.round(this.tipCount * this.minTipsPercent),
+    let muts: MutationOfInterest[];
+    if (this.interestCat === FeatureOfInterest.None) {
+      muts = this.mutationsOfInterest[FeatureOfInterest.ManyTips];
+    } else {
+      muts = this.mutationsOfInterest[this.interestCat];
+    }
+    const minTipCount = Math.round(this.tipCount * this.minTipsPercent),
       tipDistribution: number[] = [],
       treePctDistribution: number[] = [];
     let sort: (moi1: MutationOfInterest, moi2: MutationOfInterest)=>number = () => 0;

--- a/src/ts/ui/mutations/mutationsui.ts
+++ b/src/ts/ui/mutations/mutationsui.ts
@@ -23,7 +23,7 @@ if (!maybeTableBody) {
   throw new Error("mutations.html doesn't have the container for the mutation rows!");
 }
 const MUTATION_TABLE_BODY = <HTMLDivElement> maybeTableBody;
-
+const MOI_HEAD = document.querySelector(".moi-list--header") as HTMLElement;
 const MOI_LIST = document.querySelector(".moi-list--body") as HTMLElement;
 
 const MOI_TEMPLATE = MOI_LIST.querySelector(".moi") as HTMLElement;
@@ -348,8 +348,10 @@ export class MutationsUI extends MccUI {
     let muts: MutationOfInterest[];
     if (this.interestCat === FeatureOfInterest.None) {
       muts = this.mutationsOfInterest[FeatureOfInterest.ManyTips];
+      MOI_HEAD.classList.add("hidden")
     } else {
       muts = this.mutationsOfInterest[this.interestCat];
+      MOI_HEAD.classList.remove("hidden")
     }
     const minTipCount = Math.round(this.tipCount * this.minTipsPercent),
       tipDistribution: number[] = [],

--- a/src/ts/ui/mutations/mutationsui.ts
+++ b/src/ts/ui/mutations/mutationsui.ts
@@ -285,12 +285,7 @@ export class MutationsUI extends MccUI {
           }
 
           const mutationsFilter = this.div.querySelector(".mutations-filter--form") as HTMLFormElement;
-          if (this.autofill) {
-            mutationsFilter.querySelectorAll("input").forEach(radio => {
-              radio.checked = false;
-            });
-            this.div.querySelectorAll(".filter-description").forEach(ele=>ele.classList.add("hidden"));
-          } else {
+          if (!this.autofill) {
             mutationsFilter.querySelectorAll("input").forEach(radio => {
               const value = radio.value as FeatureOfInterest;
               radio.checked = value === this.interestCat;

--- a/src/ts/ui/mutations/mutationsui.ts
+++ b/src/ts/ui/mutations/mutationsui.ts
@@ -89,7 +89,8 @@ export class MutationsUI extends MccUI {
       [FeatureOfInterest.SameSite]: [],
       [FeatureOfInterest.MultipleIntroductions]: [],
       [FeatureOfInterest.ManyTips]: [],
-      ['all'] : []
+      ['all'] : [],
+      [FeatureOfInterest.None]: []
     };
     this.minTreesPercent = DEFAULT_MINIMUM_MOI_PRESENCE;
     this.minTipsPercent = DEFAULT_MINIMUM_TIP_PERCENT;
@@ -284,10 +285,16 @@ export class MutationsUI extends MccUI {
           }
 
           const mutationsFilter = this.div.querySelector(".mutations-filter--form") as HTMLFormElement;
-          mutationsFilter.querySelectorAll("input").forEach(radio => {
-            const value = radio.value as FeatureOfInterest;
-            radio.checked = value === this.interestCat;
-          });
+          if (this.autofill) {
+            mutationsFilter.querySelectorAll("input").forEach(radio => {
+              radio.checked = false;
+            });
+          } else {
+            mutationsFilter.querySelectorAll("input").forEach(radio => {
+              const value = radio.value as FeatureOfInterest;
+              radio.checked = value === this.interestCat;
+            });
+          }
           this.setInterest(this.autofill);
           this.autofill = false;
 
@@ -372,14 +379,16 @@ export class MutationsUI extends MccUI {
       tipDistribution.push(mut.medianTipCount);
       treePctDistribution.push(100 * mut.confidence);
       if (mut.confidence >= this.minTreesPercent && mut.medianTipCount >= minTipCount) {
-        this.addMoi(mut);
-        mutCount++;
+        if (!this.autofill) {
+          this.addMoi(mut);
+          mutCount++;
+        }
         if (autofill && this.rows.length < MAX_AUTOFILL_MUTATIONS) {
           this.selectMutation(mut);
         }
       }
     });
-    if (mutCount === 0) {
+    if (mutCount === 0 && this.interestCat !== FeatureOfInterest.None) {
       MOI_LIST.appendChild(NO_MUTATIONS);
     }
     this.treePercentSetter.set(treePctDistribution, this.minTreesPercent * 100, 100);

--- a/src/views/mutations.html
+++ b/src/views/mutations.html
@@ -55,7 +55,7 @@
           <div class="filter-descriptions">
             <p class="filter-description hidden" data-feature="all"><b>All</b>: no filters applied to mutations.</p>
             <p class="filter-description hidden" data-feature="reversals"><b>Reversals</b>: mutations from the root sequence that are followed by another mutation that reverts the mutated allele back to the root allele.</p>
-            <p class="filter-description" data-feature="many_tips"><b>Many tips</b>: mutations where the median number of genomes affected in the base trees is 75% or more.</p>
+            <p class="filter-description hidden" data-feature="many_tips"><b>Many tips</b>: mutations where the median number of genomes affected in the base trees is 75% or more.</p>
             <p class="filter-description hidden" data-feature="same_site"><b>Same-site</b>: mutations occuring at the same site on the genome that result in different alleles.</p>
             <p class="filter-description hidden" data-feature="multiple_introductions"><b>Recurring</b>: instances of the same mutation appearing independently multiple times.</p>
 

--- a/src/views/mutations.html
+++ b/src/views/mutations.html
@@ -58,7 +58,7 @@
             <p class="filter-description hidden" data-feature="many_tips"><b>Many tips</b>: mutations where the median number of genomes affected in the base trees is 75% or more.</p>
             <p class="filter-description hidden" data-feature="same_site"><b>Same-site</b>: mutations occuring at the same site on the genome that result in different alleles.</p>
             <p class="filter-description hidden" data-feature="multiple_introductions"><b>Recurring</b>: instances of the same mutation appearing independently multiple times.</p>
-
+            <p class="filter-description" data-feature="none">Select a feature type to see mutation details. </p>
           </div>
         </div>
         <div class="moi-list">

--- a/src/views/mutations.html
+++ b/src/views/mutations.html
@@ -39,7 +39,7 @@
                 <label for="interest--reversals">Reversals</label>
               </div>
               <div class="filter-option--tips">
-                <input type="radio" name="interest" class="radio-interest" id="interest--tips" value="many_tips" checked autocomplete="off">
+                <input type="radio" name="interest" class="radio-interest" id="interest--tips" value="many_tips" autocomplete="off">
                 <label for="interest--tips">Many tips</label>
               </div>
               <div class="filter-option--site">
@@ -110,9 +110,9 @@
               <input type="range" min="0" max="100" step="1" class="parameter-range parameter-range--trees">
             </div>
           </div>
-          <p class="parameter-info">Showing <span id="moi-list-mut-count"></span> mutation<span class="plural">s</span> appearing in at least 
-            <button id="moi-list-tips--button" class="parameter-button"><span id="moi-list-tips"></span>% of genomes</button> 
-            and present in at least 
+          <p class="parameter-info">Showing <span id="moi-list-mut-count"></span> mutation<span class="plural">s</span> appearing in at least
+            <button id="moi-list-tips--button" class="parameter-button"><span id="moi-list-tips"></span>% of genomes</button>
+            and present in at least
             <button id="moi-list-trees--button" class="parameter-button"><span id="moi-list-trees"></span>% of base trees</button>.
           </p>
         </div>


### PR DESCRIPTION
Still show some mutations on the right, the page looks too empty without it. 

Might want to bring up the "Mutation lookup" box? 

fixes #103 
