### PR TITLE
fix occasional crash when trying to select for SNP distance

### DIFF
--- a/src/ts/pythia/pythia.ts
+++ b/src/ts/pythia/pythia.ts
@@ -409,7 +409,12 @@ export class Pythia {
     return this.mccRefManager.getRef();
   }
 
-  getMccIndex(): number {
+  /*
+  of all the trees in the run (not just the trees upon
+  which the MCC is based), get the index of the tree that
+  is the basis of the MCC's topology.
+  */
+  getAbsoluteMccIndex(): number {
     let index = -1;
     if (this.mccRefManager) {
       index = this.kneeIndex + this.mccRefManager.mccIndex;

--- a/src/ts/ui/customize/customizeui.ts
+++ b/src/ts/ui/customize/customizeui.ts
@@ -120,7 +120,7 @@ export class CustomizeUI extends MccUI {
         imgTreeCanvas.setConfig(mccConfig);
         mccConfig.updateInnerNodeMetadata(tree);
       }
-      imgTreeCanvas.positionTreeNodes(tree, conf, this.pythia?.getMccIndex());
+      imgTreeCanvas.positionTreeNodes(tree, conf, this.pythia?.getAbsoluteMccIndex());
       // const mcccc = this.mccTreeCanvas.canvas;
       // (mcccc.parentNode as HTMLElement).insertBefore(canvas, mcccc);
       imgTreeCanvas.draw(this.minDate, this.maxDate, this.timelineIndices);
@@ -160,7 +160,7 @@ export class CustomizeUI extends MccUI {
           imgTreeCanvas.setConfig(mccConfig);
           mccConfig.updateInnerNodeMetadata(tree);
         }
-        imgTreeCanvas.positionTreeNodes(tree, conf, this.pythia?.getMccIndex());
+        imgTreeCanvas.positionTreeNodes(tree, conf, this.pythia?.getAbsoluteMccIndex());
         // const mcccc = this.mccTreeCanvas.canvas;
         // (mcccc.parentNode as HTMLElement).insertBefore(canvas, mcccc);
         imgTreeCanvas.draw(this.minDate, this.maxDate, this.timelineIndices, canvas);

--- a/src/ts/ui/mccui.ts
+++ b/src/ts/ui/mccui.ts
@@ -128,7 +128,8 @@ export class MccUI extends UIScreen {
         if (mccConfig) {
           mccConfig.updateInnerNodeMetadata(summary);
         }
-        this.mccTreeCanvas.positionTreeNodes(summary, nodeConfidence, pythia.getMccIndex());
+        const mccManager = mccRef.getManager();
+        this.mccTreeCanvas.positionTreeNodes(summary, nodeConfidence, mccManager.mccIndex);
         requestAnimationFrame(()=>document.body.classList.remove("summarizing"));
         this.requestTreeDraw();
         resolve(summary);

--- a/src/ts/ui/runner/runui.ts
+++ b/src/ts/ui/runner/runui.ts
@@ -1043,7 +1043,7 @@ export class RunUI extends UIScreen {
     if (mccRef) {
       const oldRef = this.mccRef;
       this.mccRef = mccRef;
-      this.mccIndex = this.pythia.getMccIndex();
+      this.mccIndex = this.pythia.getAbsoluteMccIndex();
       const mccTree = mccRef.getMcc(),
         nodeConfidence = mccRef.getNodeConfidence();
       if (mccTree !== this.mccTreeCanvas.tree) {


### PR DESCRIPTION
bug fix: when laying out by SNP distance, we were using the wrong tree index. Rather than the index from all the trees (including burn in), we need the index from among the trees in the MCC


fixes #121 