### PR TITLE
hide info button next to MCC label on run page

### DIFF
--- a/src/style/runner.less
+++ b/src/style/runner.less
@@ -305,6 +305,9 @@
   width: var(--tree-container-min-width);
   min-width: var(--tree-container-min-width);
   max-width: var(--tree-container-max-width);
+
+  .title .info { display: none; }
+
   .tree-container {
     height: calc(100% - 100px);
   }


### PR DESCRIPTION
fixes #96 