### PR TITLE
metadata loading improvements

### DIFF
--- a/src/ts/ui/customize/customizeui.ts
+++ b/src/ts/ui/customize/customizeui.ts
@@ -637,8 +637,12 @@ const parseMetadataFile = (file: File, mccConfig: MccConfig, mccTreeCanvas: MccT
         const tabCount = first.split('\t').length - 1;
         separator = commaCount > tabCount ? ',' : '\t';
       }
-      const metadata = new Metadata(file.name, text, separator);
-      mccConfig.setMetadata(metadata, mccTreeCanvas.tree as SummaryTree);
+      try {
+        const metadata = new Metadata(file.name, text, separator);
+        mccConfig.setMetadata(metadata, mccTreeCanvas.tree as SummaryTree);
+      } catch(err) {
+        console.debug(err)
+      }
       callback();
     });
     reader.readAsText(file);

--- a/src/ts/ui/customize/customizeui.ts
+++ b/src/ts/ui/customize/customizeui.ts
@@ -11,7 +11,6 @@ import { MccTree, SummaryTree } from '../../pythia/delphy_api';
 import { MccTreeCanvas } from '../mcctreecanvas';
 import { PdfCanvas } from '../../util/pdfcanvas';
 import * as JSZip from 'jszip';
-import { MccConfig } from '../mccconfig';
 
 /* global NodeListOf */
 
@@ -437,13 +436,23 @@ export class CustomizeUI extends MccUI {
         return;
       }
     }
-    mccConfig.setMetadata(md, this.mccTreeCanvas.tree as SummaryTree, false);
-    this.setMetadataLoaded();
-    if (this.sharedState.mccConfig.hasMetadata()) {
-      const input = (this.div.querySelector("#color-system--metadata") as HTMLInputElement);
-      input.click();
-      this.setMetadataDisplay();
+    try {
+      mccConfig.setMetadata(md, this.mccTreeCanvas.tree as SummaryTree, false);
+      this.setMetadataLoaded();
+      if (this.sharedState.mccConfig.hasMetadata()) {
+        const input = (this.div.querySelector("#color-system--metadata") as HTMLInputElement);
+        input.click();
+        this.setMetadataDisplay();
+      }
+    } catch (err) {
+      if (this.sharedState.mccConfig.hasMetadata()) {
+        this.sharedState.mccConfig.clearMetadata();
+      }
+      this.setMetadataLoaded();
+      console.warn("could not load metadata:", err);
+      alert("Delphy had trouble parsing your metadata. Try a different file, or if that doesn't work, contact us at delphy@fathom.info.");
     }
+
   }
 
 

--- a/src/ts/ui/customize/customizeui.ts
+++ b/src/ts/ui/customize/customizeui.ts
@@ -420,7 +420,24 @@ export class CustomizeUI extends MccUI {
     (this.div.querySelector("#metadata-file") as HTMLElement).classList.add("loading");
   }
 
-  endMetadataLoading() : void {
+  endMetadataLoading(md: null | Metadata) : void {
+    if (!md) {
+      this.setMetadataLoaded();
+      return;
+    }
+    const mccConfig = this.sharedState.mccConfig;
+    if (this.metadataLoaded) {
+      const loadIt = confirm("Metadata is already set for this file. Do you want to replace it?");
+      if (loadIt) {
+        this.div.querySelectorAll("#metadata-column-headings .column-heading").forEach(el => el.remove());
+        mccConfig.metadataField = null;
+        this.metadataLoaded = false;
+      } else {
+        this.setMetadataLoaded();
+        return;
+      }
+    }
+    mccConfig.setMetadata(md, this.mccTreeCanvas.tree as SummaryTree, false);
     this.setMetadataLoaded();
     if (this.sharedState.mccConfig.hasMetadata()) {
       const input = (this.div.querySelector("#color-system--metadata") as HTMLInputElement);
@@ -576,7 +593,7 @@ export class CustomizeUI extends MccUI {
 
 
   parseMetadataFile(file: File) {
-    parseMetadataFile(file, this.sharedState.mccConfig, this.mccTreeCanvas, ()=>this.endMetadataLoading());
+    parseMetadataFile(file, (metadata: null | Metadata)=>this.endMetadataLoading(metadata));
   }
 
 
@@ -618,7 +635,7 @@ adding metadata does not have to be part of the customize page.
 If we _do_ decide to move it out of here, this is what it will require.
 [mark 241125]
 */
-const parseMetadataFile = (file: File, mccConfig: MccConfig, mccTreeCanvas: MccTreeCanvas, callback: ()=>void)=>{
+const parseMetadataFile = (file: File, callback: (metadata:null|Metadata)=>void)=>{
   let separator = "";
   if (file.type === "text/tab-separated-values" || file.name.endsWith(".tsv")) {
     separator = "\t";
@@ -626,6 +643,7 @@ const parseMetadataFile = (file: File, mccConfig: MccConfig, mccTreeCanvas: MccT
     separator = ",";
   }
   const reader = new FileReader();
+  let metadata: null | Metadata = null;
   try {
     reader.addEventListener("load", ()=>{
       const text = reader.result as string;
@@ -638,12 +656,11 @@ const parseMetadataFile = (file: File, mccConfig: MccConfig, mccTreeCanvas: MccT
         separator = commaCount > tabCount ? ',' : '\t';
       }
       try {
-        const metadata = new Metadata(file.name, text, separator);
-        mccConfig.setMetadata(metadata, mccTreeCanvas.tree as SummaryTree);
+        metadata = new Metadata(file.name, text, separator);
       } catch(err) {
         console.debug(err)
       }
-      callback();
+      callback(metadata);
     });
     reader.readAsText(file);
   } catch (err) {

--- a/src/ts/ui/mccconfig.ts
+++ b/src/ts/ui/mccconfig.ts
@@ -62,7 +62,6 @@ export class MccConfig {
   metadataColorsDirty: boolean;
 
 
-
   /*
   used to notify a listener that a change has occurred.
   Instead of notifying of specific change, the listening
@@ -137,11 +136,18 @@ export class MccConfig {
     this.updateCallback = callback;
   }
 
-  setMetadata(metadata: Metadata, tree: SummaryTree) : void {
+
+  /*
+  @param applyUpdate: you can send `false` when there's other work to be done
+  before updating the current page with the metadata.
+  */
+  setMetadata(metadata: Metadata, tree: SummaryTree, applyUpdate = true) : void {
     this.metadata = metadata;
     this.nodeMetadata = new NodeMetadata(metadata, tree, tree.getBaseTree(0));
     this.metadata.summarize(this.nodeMetadata);
-    this.updateCallback();
+    if (applyUpdate) {
+      this.updateCallback();
+    }
   }
 
   setMetadataField(field: string, colors: ColorDict) : void {

--- a/src/ts/ui/mccconfig.ts
+++ b/src/ts/ui/mccconfig.ts
@@ -305,6 +305,11 @@ export class MccConfig {
     }
   }
 
+  clearMetadata() : void {
+    this.nodeMetadata = null;
+    this.metadataField = null;
+  }
+
   hasMetadata() : boolean {
     return this.nodeMetadata !== null;
   }

--- a/src/ts/ui/metadata.ts
+++ b/src/ts/ui/metadata.ts
@@ -112,23 +112,46 @@ export class Metadata {
     /*
     track all the different values in the metadata file…
     */
+    const colsWithoutHeaderCounts: number[] = [];
     this.rows.forEach(row => {
       row.forEach((value, colNum) => {
         if (!this.columnSummaries[colNum]) {
           console.warn(`no column summary for column ${colNum + 1} (value: '${value}')`);
+          if (colsWithoutHeaderCounts[colNum] === undefined) {
+            colsWithoutHeaderCounts[colNum] = 1;
+          } else {
+            colsWithoutHeaderCounts[colNum]++;
+          }
         } else {
           this.columnSummaries[colNum].initValue(value);
         }
       });
     });
+
+    if (colsWithoutHeaderCounts.length > 0) {
+      let missingHeaderMsg = '';
+      const headerlessCols = colsWithoutHeaderCounts.map((count, colNum) => [count, colNum]).filter(item=>!!item);
+      if (headerlessCols.length === 1) {
+        const [count] = headerlessCols[0];
+        missingHeaderMsg = `We detected a column in the metadata file with data for ${ count } rows but no header.`;
+      } else {
+        missingHeaderMsg = `We detected ${ headerlessCols.length } columns in the metadata file without headers.`;
+      }
+      alert(`${missingHeaderMsg} We can't track columns without headers, but you can try to fix the file and reload it.`);
+    }
+
     /*
     …but only tally the ones that show up in the tree
+    ---- note: I don't think we are constraining our tallies
+    to the records that are in the tree (and we still should) [mark 260818]
     */
     nodeMetadata.tipMetadataRow.forEach((metadataRowIndex)=>{
       const row = this.rows[metadataRowIndex];
       if (row) {
         row.forEach((value, colNum) => {
-          this.columnSummaries[colNum].add(value);
+          if (this.columnSummaries[colNum] !== undefined) {
+            this.columnSummaries[colNum].add(value);
+          }
         });
       }
     });

--- a/src/ts/ui/metadata.ts
+++ b/src/ts/ui/metadata.ts
@@ -75,10 +75,13 @@ export class Metadata {
     const lines = text.split('\n');
     const rows = [];
     while (lines.length) {
-      const row = handleLine(lines, delimiter)
-      rows.push(row.map(cleanup));
+      try {
+        const row = handleLine(lines, delimiter)
+        rows.push(row.map(cleanup));
+      } catch (err) {
+        console.warn("err while parsing", err);
+      }
     }
-
 
     const header = rows.shift();
     if (!header) {


### PR DESCRIPTION
If the app can't parse the metadata, have it recover without breaking. 

Allow the user to replace the existing metadata file with another (and prompt them before they lose their old file). 



fixes #60