### PR TITLE
Limit the number of mutations that we draw on the lineages tab

### DIFF
--- a/src/style/lineages.less
+++ b/src/style/lineages.less
@@ -840,7 +840,9 @@ details {
   margin: 0;
   height: calc( 40px * 5 + 7.5px * 4);
   overflow: hidden;
-  transition: height 0.15s;
+  &.windowshading {
+    transition: height 0.15s;
+  }
 }
 
 .lineages--node-comparison--show-toggle {

--- a/src/style/lineages.less
+++ b/src/style/lineages.less
@@ -828,7 +828,29 @@ details {
 .lineages--node-comparison--time-chart-container {
   // padding-left: 15px;
   // border-left: solid 1px rgb(225,225,225);
+
+  &:has(.lineages--node-comparison--show-toggle input:checked) {
+    .lnc-min-count { display: none; }
+  }
+
 }
+
+.lineages--node-comparison--mutation-list {
+  padding: 0;
+  margin: 0;
+  height: calc( 40px * 5 + 7.5px * 4);
+  overflow: hidden;
+  transition: height 0.15s;
+}
+
+.lineages--node-comparison--show-toggle {
+  .lnc-less { display: none;}
+  &:has(input:checked) {
+    .lnc-less { display: inline; }
+    .lnc-all { display: none; }
+  }
+}
+
 
 .lineages--node-comparison--time-chart {
   //background-color: rgb(250, 250, 250);
@@ -847,7 +869,7 @@ details {
   color: rgb(114, 114, 114);
 }
 
-.lineages--node-comparison--mutation-count {
+.lnc-mutation-min, .lineages--node-comparison--mutation-count {
   font-weight: bolder;
 }
 

--- a/src/style/lineages.less
+++ b/src/style/lineages.less
@@ -838,7 +838,7 @@ details {
 .lineages--node-comparison--mutation-list {
   padding: 0;
   margin: 0;
-  height: calc( 40px * 5 + 7.5px * 4);
+  // height: calc( 40px * 5 + 7.5px * 4);
   overflow: hidden;
   &.windowshading {
     transition: height 0.15s;

--- a/src/ts/pythia/mutationdistribution.ts
+++ b/src/ts/pythia/mutationdistribution.ts
@@ -6,6 +6,7 @@ export class MutationDistribution {
   // treeIndices: number[];
   possibleTrees: number;
   isApobecCtx: boolean;
+  treeIndices: Set<number>;
 
   constructor(mut: Mutation, totalTrees: number, isApobecCtx: boolean) {
     this.mutation = mut;
@@ -13,6 +14,7 @@ export class MutationDistribution {
     // this.treeIndices = [];
     this.possibleTrees = totalTrees;
     this.isApobecCtx = isApobecCtx;
+    this.treeIndices = new Set();
   }
 
   // addTime(t: number, treeIndex: number): void {
@@ -20,12 +22,13 @@ export class MutationDistribution {
   //   this.treeIndices.push(treeIndex);
   // }
 
-  addTime(t: number): void {
+  addTime(t: number, treeIndex: number): void {
+    this.treeIndices.add(treeIndex);
     this.times.push(t);
   }
 
   getConfidence():number {
-    return this.times.length / this.possibleTrees;
+    return this.treeIndices.size / this.possibleTrees;
   }
 
 }

--- a/src/ts/pythia/pythia.ts
+++ b/src/ts/pythia/pythia.ts
@@ -941,6 +941,7 @@ export class Pythia {
     let muts: MutationDistribution[] = [];
     if (downstreamMccNodeIndex !== UNSET) {
       let rootSeq: Uint8Array;
+      let treeIndex = 0;
       const treeCount = tree.getNumBaseTrees(),
         mutationLookup: { [name: string]: MutationDistribution } = {},
         tallyMutation = (mut:Mutation)=>{
@@ -949,7 +950,7 @@ export class Pythia {
             const isApobecCtx = checkApobecCtx(mut, rootSeq);
             mutationLookup[name] = new MutationDistribution(mut, treeCount, isApobecCtx);
           }
-          mutationLookup[name].addTime(mut.time);
+          mutationLookup[name].addTime(mut.time, treeIndex);
         },
         /*
           first we find the set of trees in the mcc that contain both nodes
@@ -959,7 +960,7 @@ export class Pythia {
         const nodeIndex = tree.getCorrespondingNodeInBaseTree(upstreamMccNodeIndex, treeIndex);
         upstreamTrees[treeIndex] = nodeIndex;
       }
-      for (let treeIndex = 0; treeIndex < tree.getNumBaseTrees(); treeIndex++) {
+      for (treeIndex = 0; treeIndex < tree.getNumBaseTrees(); treeIndex++) {
         try {
           const upstreamIndex = upstreamTrees[treeIndex];
           if (upstreamIndex !== undefined) {

--- a/src/ts/ui/basetreemeancanvas.ts
+++ b/src/ts/ui/basetreemeancanvas.ts
@@ -162,7 +162,7 @@ export class BaseTreeMeanCanvas {
   protected draw() : void {
     const { ctx, width, height, averages, averageYPositions } = this;
 
-    console.log(averages, averageYPositions);
+    // console.log(averages, averageYPositions);
 
     ctx.clearRect(0, 0, width, height);
 

--- a/src/ts/ui/lineages/lineagesui.ts
+++ b/src/ts/ui/lineages/lineagesui.ts
@@ -792,6 +792,16 @@ export class LineagesUI extends MccUI {
   assembleNodePair(index1: number, index2: number, nodePairType: NodePairType, pythia: Pythia): NodePair {
     const tree = this.mccTreeCanvas.tree as SummaryTree,
       mutTimes : MutationDistribution[] = pythia.getMccMutationsBetween(index1, index2, tree);
+    mutTimes.sort((a, b)=>{
+      let diff = b.getConfidence() - a.getConfidence();
+      if (diff === 0) {
+        diff = a.times[0] - b.times[0];
+        if (diff === 0) {
+          diff = a.mutation.site - b.mutation.site;
+        }
+      }
+      return diff;
+    });
     return new NodePair(index1, index2, nodePairType, mutTimes);
   }
 

--- a/src/ts/ui/lineages/nodecomparison.ts
+++ b/src/ts/ui/lineages/nodecomparison.ts
@@ -6,7 +6,9 @@ import { DistributionSeries, TimeDistributionCanvas } from '../timedistributionc
 import { Mutation } from '../../pythia/delphy_api';
 import { HighlightableTimeDistributionCanvas, HoverCallback } from './highlightabletimedistributioncanvas';
 
-// const MAX_MUTATIONS_PER_NODE = 10;
+const MAX_MUTATIONS_PER_NODE = 5;
+const MUT_BOX_HT = 40;
+const MUT_BOX_MARGIN = 7.5;
 
 const nodeComparisonTemplate = document.querySelector(".lineages--node-comparison") as HTMLDivElement;
 const nodeComparisonContainer = nodeComparisonTemplate?.parentNode as HTMLDivElement;
@@ -21,7 +23,7 @@ nodeComparisonTemplate.remove();
 const mutationCanvasSelector = '.lineages--mutation-time-chart',
   mutationNameSelector = '.lineages--node-comparison--mutation-name',
   mutationPrevalenceSelector = '.lineages--node-comparison--mutation-prevalence span',
-  mutationContainerSelector = '.lineages--node-comparison--time-chart-container',
+  mutationContainerSelector = '.lineages--node-comparison--mutation-list',
   ancestorNodeNameSelector = '.lineages--node-comparison--ancestor-node',
   descendantNodeNameSelector = '.lineages--node-comparison--descendant-node',
   mutationCountSelector = '.lineages--node-comparison--mutation-count',
@@ -108,12 +110,16 @@ export class NodeComparison {
   nodeTimesCanvas: HighlightableTimeDistributionCanvas;
   minDate: number;
   maxDate: number;
+  mutationData: MutationDistribution[];
   mutationTimelines:MutationTimeline[];
   mutationContainer: HTMLDivElement;
   goToMutations: MutationFunctionType;
   ancestorType: DisplayNode;
   descendantType: DisplayNode;
   nodeHighlightCallback: NodeCallback;
+  showAllMutsToggle: HTMLInputElement;
+  isApobecRun: boolean;
+
 
   constructor(nodeComparisonData : NodeComparisonData, minDate: number, maxDate: number,
     goToMutations: MutationFunctionType, nodeHighlightCallback: NodeCallback, isApobecRun: boolean) {
@@ -139,7 +145,9 @@ export class NodeComparison {
     this.minDate = minDate;
     this.maxDate = maxDate;
     this.mutationTimelines = [];
+    this.mutationData = [];
     this.goToMutations = goToMutations;
+    this.isApobecRun = isApobecRun;
 
     this.ancestorType = getAncestorType(this.nodePair.pairType);
     this.descendantType = getDescendantType(this.nodePair.pairType);
@@ -163,9 +171,13 @@ export class NodeComparison {
     } else {
       overlapSpan.classList.add('hidden');
     }
+    this.showAllMutsToggle = this.div.querySelector(".lineages--node-comparison--show-toggle input") as HTMLInputElement;
+    this.showAllMutsToggle.addEventListener("input", ()=>{
+      this.requestDraw();
+    });
 
 
-    this.setMutations(isApobecRun);
+    this.setMutations();
 
     const createSeries = (dn: DisplayNode, i: number) => {
       const typeName = getNodeTypeName(dn);
@@ -213,19 +225,9 @@ export class NodeComparison {
     this.node2Span.classList.add(getNodeClassName(descendantType));
   }
 
-  setMutations(isApobecRun: boolean):void {
-    const shownMutations = this.nodePair.mutations.filter((md:MutationDistribution)=>md.getConfidence() >= mutationPrevalenceThreshold);
-    const count = shownMutations.length,
-      minDate = this.minDate,
-      maxDate = this.maxDate;
-    // if (shownMutations.length > MAX_MUTATIONS_PER_NODE) {
-    //   shownMutations = shownMutations.slice(0, MAX_MUTATIONS_PER_NODE);
-    // }
-    this.mutationTimelines = shownMutations.map((md:MutationDistribution)=>{
-      const mt = new MutationTimeline(md, minDate, maxDate, this.goToMutations, isApobecRun);
-      mt.appendTo(this.mutationContainer);
-      return mt;
-    });
+  setMutations():void {
+    this.mutationData = this.nodePair.mutations.filter((md:MutationDistribution)=>md.getConfidence() >= mutationPrevalenceThreshold);
+    const count = this.mutationData.length;
     this.mutationCountSpan.innerText = `${count} mutation${count === 1 ? '' : 's'}`;
     let thresholdLabel = `${getPercentLabel(mutationPrevalenceThreshold)}%`;
     if (mutationPrevalenceThreshold < 1.0) {
@@ -235,9 +237,24 @@ export class NodeComparison {
   }
 
   requestDraw() : void {
+    const count = this.mutationData.length;
+    const shownCount = this.showAllMutsToggle.checked ? count : Math.min(count, MAX_MUTATIONS_PER_NODE);
+    const mHeight = shownCount * (MUT_BOX_HT + MUT_BOX_MARGIN) - MUT_BOX_MARGIN;
+    const alreadyDrawnCount = this.mutationTimelines.length;
+    if (alreadyDrawnCount < shownCount) {
+      const { minDate, maxDate, goToMutations, isApobecRun } = this;
+      this.mutationData.slice(alreadyDrawnCount, shownCount).forEach(md => {
+        const mt = new MutationTimeline(md, minDate, maxDate, goToMutations, isApobecRun);
+        this.mutationTimelines.push(mt);
+      });
+    }
     requestAnimationFrame(()=>{
       this.nodeTimesCanvas.draw();
-      this.mutationTimelines.forEach(mt=>mt.draw());
+      this.mutationTimelines.slice(alreadyDrawnCount, shownCount).forEach(mt=>{
+        mt.appendTo(this.mutationContainer);
+        mt.draw();
+      });
+      this.mutationContainer.style.height = `${mHeight}px`;
     });
   }
 

--- a/src/ts/ui/lineages/nodecomparison.ts
+++ b/src/ts/ui/lineages/nodecomparison.ts
@@ -179,7 +179,9 @@ export class NodeComparison {
     this.showAllMutsToggleLabel = this.div.querySelector(".lineages--node-comparison--show-toggle") as HTMLLabelElement;
     this.showAllMutsToggle = this.showAllMutsToggleLabel.querySelector("input") as HTMLInputElement;
     this.showAllMutsToggle.addEventListener("input", ()=>{
+      this.mutationContainer.classList.add("windowshading");
       this.requestDraw();
+      setTimeout(() => this.mutationContainer.classList.remove("windowshading"), 150);
     });
 
 

--- a/src/ts/ui/lineages/nodecomparison.ts
+++ b/src/ts/ui/lineages/nodecomparison.ts
@@ -27,6 +27,7 @@ const mutationCanvasSelector = '.lineages--mutation-time-chart',
   ancestorNodeNameSelector = '.lineages--node-comparison--ancestor-node',
   descendantNodeNameSelector = '.lineages--node-comparison--descendant-node',
   mutationCountSelector = '.lineages--node-comparison--mutation-count',
+  showMutationSelector = '.lineages--node-comparison--mutation-header .lnc-mutation-min',
   mutationThresholdSelector = '.lineages--node-comparison--mutation-threshold',
   nodeTimesCanvasSelector = '.lineages--node-comparison--time-chart canvas';
 
@@ -105,6 +106,7 @@ export class NodeComparison {
   node1Span: HTMLSpanElement;
   node2Span: HTMLSpanElement;
   mutationCountSpan: HTMLSpanElement;
+  shownMutationCountSpan: HTMLSpanElement;
   mutationThresholdSpan: HTMLSpanElement;
   nodePair: NodePair;
   nodeTimesCanvas: HighlightableTimeDistributionCanvas;
@@ -117,6 +119,7 @@ export class NodeComparison {
   ancestorType: DisplayNode;
   descendantType: DisplayNode;
   nodeHighlightCallback: NodeCallback;
+  showAllMutsToggleLabel: HTMLLabelElement;
   showAllMutsToggle: HTMLInputElement;
   isApobecRun: boolean;
 
@@ -129,6 +132,7 @@ export class NodeComparison {
       node1Span = this.div.querySelector(ancestorNodeNameSelector) as HTMLSpanElement,
       node2Span = this.div.querySelector(descendantNodeNameSelector) as HTMLSpanElement,
       mutationCountSpan = this.div.querySelector(mutationCountSelector) as HTMLSpanElement,
+      shownMutationCountSpan = this.div.querySelector(showMutationSelector) as HTMLSpanElement,
       mutationThresholdSpan = this.div.querySelector(mutationThresholdSelector) as HTMLSpanElement,
       canvas = this.div.querySelector(nodeTimesCanvasSelector) as HTMLCanvasElement,
       overlapSpan = this.div.querySelector(".lineages--node-overlap-item") as HTMLSpanElement,
@@ -140,6 +144,7 @@ export class NodeComparison {
     this.node1Span = node1Span;
     this.node2Span = node2Span;
     this.mutationCountSpan = mutationCountSpan;
+    this.shownMutationCountSpan = shownMutationCountSpan;
     this.mutationThresholdSpan = mutationThresholdSpan;
     this.mutationContainer = mutationContainer;
     this.minDate = minDate;
@@ -171,7 +176,8 @@ export class NodeComparison {
     } else {
       overlapSpan.classList.add('hidden');
     }
-    this.showAllMutsToggle = this.div.querySelector(".lineages--node-comparison--show-toggle input") as HTMLInputElement;
+    this.showAllMutsToggleLabel = this.div.querySelector(".lineages--node-comparison--show-toggle") as HTMLLabelElement;
+    this.showAllMutsToggle = this.showAllMutsToggleLabel.querySelector("input") as HTMLInputElement;
     this.showAllMutsToggle.addEventListener("input", ()=>{
       this.requestDraw();
     });
@@ -229,6 +235,9 @@ export class NodeComparison {
     this.mutationData = this.nodePair.mutations.filter((md:MutationDistribution)=>md.getConfidence() >= mutationPrevalenceThreshold);
     const count = this.mutationData.length;
     this.mutationCountSpan.innerText = `${count} mutation${count === 1 ? '' : 's'}`;
+    const shownCount = this.showAllMutsToggle.checked ? count : Math.min(count, MAX_MUTATIONS_PER_NODE);
+    this.shownMutationCountSpan.innerText = `${shownCount}`;
+    this.showAllMutsToggleLabel.classList.toggle("hidden", shownCount === count);
     let thresholdLabel = `${getPercentLabel(mutationPrevalenceThreshold)}%`;
     if (mutationPrevalenceThreshold < 1.0) {
       thresholdLabel += ' or more'

--- a/src/views/lineages.html
+++ b/src/views/lineages.html
@@ -173,24 +173,35 @@
               </div>
             </div>
             <p class="lineages--node-comparison--mutation-header">
-              <span class="lineages--node-comparison--mutation-count">0 mutations</span> between nodes appear in
-              <span class="lineages--node-comparison--mutation-threshold">50%</span> of base trees;
+              Mutations between these nodes that appear in
+              <span class="lineages--node-comparison--mutation-threshold">50%</span>
+              of base trees.
+              <br/>
+              Showing <span class="lnc-min-count"><span class="lnc-mutation-min">5</span> of</span>
+              <span class="lineages--node-comparison--mutation-count">0 mutations</span>
+              <label class="lineages--node-comparison--show-toggle">
+                <input type="checkbox">
+                <span class="lnc-all">Show all</span>
+                <span class="lnc-less">Show less</span>
+              </label>
             </p>
-            <div class="lineages--node-comparison--mutation">
-              <div class="lineages--node-comparison--mutation-labels">
-                <a class="lineages--node-comparison--mutation-name mutation-name" href="">
-                  <span class="allele allele-from"></span><span class="site"></span><span class="allele allele-to"></span>
-                </a>
-                <span class="lineages--node-comparison--mutation-is-apobec">APOBEC</span>
-                <p class="lineages--node-comparison--mutation-prevalence"><span>99%</span> of base trees</p>
-              </div>
-              <div class="lineages--mutation-time-chart-container">
-                <canvas class="lineages--mutation-time-chart"></canvas>
-                <div class="time-chart--readout">
-                  <div class="time-chart--date"></div>
-                  <div class="time-chart--series">
-                    <span class="value-label">##%</span>
-                    <span class="series-label"></span>
+            <div class="lineages--node-comparison--mutation-list">
+              <div class="lineages--node-comparison--mutation">
+                <div class="lineages--node-comparison--mutation-labels">
+                  <a class="lineages--node-comparison--mutation-name mutation-name" href="">
+                    <span class="allele allele-from"></span><span class="site"></span><span class="allele allele-to"></span>
+                  </a>
+                  <span class="lineages--node-comparison--mutation-is-apobec">APOBEC</span>
+                  <p class="lineages--node-comparison--mutation-prevalence"><span>99%</span> of base trees</p>
+                </div>
+                <div class="lineages--mutation-time-chart-container">
+                  <canvas class="lineages--mutation-time-chart"></canvas>
+                  <div class="time-chart--readout">
+                    <div class="time-chart--date"></div>
+                    <div class="time-chart--series">
+                      <span class="value-label">##%</span>
+                      <span class="series-label"></span>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
When hovering nodes on the lineages tab, the number of mutations can get very long. This impacts readability and performance. 

Here we limit the number of mutations drawn for each node pair by default, but make the full list available. 

It's not elegant, but it works. 

fixes #41