### PR TITLE
fix pdf exports 

### DIFF
--- a/src/ts/util/pdfcanvas.ts
+++ b/src/ts/util/pdfcanvas.ts
@@ -26,8 +26,6 @@ export class PdfCanvas {
   getContext(): Context2d {return this.ctx;}
 
   save(filename: string): void {
-    /* get rid of the first blank page */
-    this.doc.deletePage(1);
     this.doc.save(filename);
   }
 


### PR DESCRIPTION
old jspdf inserted an extra page in the doc that we had to get rid of. Doesn't look like we need to do that anymore.

fixes #139 