### PR TITLE
Fix occasional hang on start

### DIFF
--- a/src/ts/ui/runner/scatterplotcanvas.ts
+++ b/src/ts/ui/runner/scatterplotcanvas.ts
@@ -226,6 +226,9 @@ export class ScatterPlotCanvas extends TraceCanvas {
   drawLabels():void {
     const { minSpan, maxSpan, dataHeight, svg } = this;
     const { dataMin, dataMax, minDate, maxDate } = this.traceData as ScatterData;
+    if (minDate === UNSET && maxDate === UNSET) {
+      return;
+    }
     const countRange = dataMax - dataMin;
     svg.querySelectorAll(TICK_SELECTOR).forEach(ele=>ele.remove());
     svg.querySelectorAll(TICK_LABEL_SELECTOR).forEach(ele=>ele.remove());
@@ -235,6 +238,9 @@ export class ScatterPlotCanvas extends TraceCanvas {
     const tickInterval = nicenum(Math.ceil(countRange / tickCount));
     const tickSpacing = (tickInterval / countRange) * dataHeight;
     const labelInterval = tickSpacing >= LABEL_SPACING ? 1 : 5;
+    if (tickInterval === 0) {
+      return;
+    }
     let drawnTicks = 0;
     for (let i = 0; i <= countRange; i += tickInterval) {
       const y = MARGIN.top + (1 - i / countRange) * dataHeight;


### PR DESCRIPTION
It turns out that the run page histcanvases can receive hover events before the page is actually rendered. This eventually triggers rendering the scatterplot. If there's no data yet, this results in as infinite loop: the scatter plot calculates the interval between ticks based on the date range, and if the range is 0, then the loop that generates the ticks increments by 0 too. Which goes on FOREVER. 

The fix is to add some guards to the scatterplot code to not render ticks if the range is 0. 

fixes #143