### PR TITLE
Uploader screen width

### DIFF
--- a/src/style/uploader.less
+++ b/src/style/uploader.less
@@ -1144,7 +1144,7 @@
 
 }
 
-@media (max-width: 950px) {
+@media (max-width: 1250px) {
 
   #uploader--content-div {
     padding: unset;


### PR DESCRIPTION
Changed one thing to avoid the uploading page to be in this state

<img width="1031" height="1033" alt="Screenshot 2026-08-20 at 4 25 00 PM" src="https://github.com/user-attachments/assets/9f02cb39-45aa-4514-9596-cc06008cc871" />
